### PR TITLE
feat(swift-worker): ship on-device verdicts over the wire (Tier 1)

### DIFF
--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -1781,6 +1781,15 @@ class OCRProcessor:
         if not sections_payload and not items_payload:
             return None
 
+        # Receipt-level verdict the worker computed on device (additive;
+        # absent on payloads from earlier worker builds). The graded
+        # baseline agreement is stamped on every row so worker rows carry
+        # the same #1324 diagnostics as cloud-recomputed ones.
+        reconciliation = receipt_data.get("reconciliation") or {}
+        figures_agreeing = reconciliation.get("baseline_figures_agreeing")
+        if not isinstance(figures_agreeing, int):
+            figures_agreeing = None
+
         sections: list[ReceiptSection] = []
         for entry in sections_payload:
             try:
@@ -1844,13 +1853,16 @@ class OCRProcessor:
                         quantity=entry.get("quantity"),
                         unit_price=entry.get("unit_price"),
                         is_discount=bool(entry.get("is_discount")),
+                        raw_text=str(entry.get("raw_text") or ""),
                         name_quality=quality,
-                        # No summary exists at ingest, so the worker's
-                        # reconciliation is almost always "no-baseline"; the
-                        # stream stage re-reconciles once one is written.
+                        # The worker reconciles against its own SCANNED
+                        # printed figures (no summary exists at ingest);
+                        # the stream stage re-reconciles against the real
+                        # summary once one is written.
                         reconciliation_status=(
                             entry.get("reconciliation_status") or None
                         ),
+                        baseline_figures_agreeing=figures_agreeing,
                         source_model_source=SWIFT_WORKER_MODEL_SOURCE,
                         source_section_status=ValidationStatus.PENDING.value,
                     )
@@ -1882,6 +1894,12 @@ class OCRProcessor:
             "extractor_version": (
                 line_items[0].extractor_version if line_items else None
             ),
+            "printed_subtotal": receipt_data.get("printed_subtotal"),
+            "should_reocr_items_zone": receipt_data.get(
+                "should_reocr_items_zone"
+            ),
+            "reconciliation_status": reconciliation.get("status"),
+            "baseline_source": reconciliation.get("baseline_source"),
         }
         logger.info(
             "Persisted worker-decoded structure for %s:%s: %s",

--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -1794,8 +1794,16 @@ class OCRProcessor:
                 reconciliation,
             )
             reconciliation = {}
+        # The entity documents the grade as an int in 1..3 and raises on
+        # anything else -- including ``True``, since bool subclasses int.
+        # An out-of-band value would fail every row's construction and cost
+        # the receipt its whole line-item set, so drop it to None instead.
         figures_agreeing = reconciliation.get("baseline_figures_agreeing")
-        if not isinstance(figures_agreeing, int):
+        if (
+            isinstance(figures_agreeing, bool)
+            or not isinstance(figures_agreeing, int)
+            or not 1 <= figures_agreeing <= 3
+        ):
             figures_agreeing = None
 
         sections: list[ReceiptSection] = []

--- a/infra/upload_images/container_ocr/handler/ocr_processor.py
+++ b/infra/upload_images/container_ocr/handler/ocr_processor.py
@@ -1786,6 +1786,14 @@ class OCRProcessor:
         # baseline agreement is stamped on every row so worker rows carry
         # the same #1324 diagnostics as cloud-recomputed ones.
         reconciliation = receipt_data.get("reconciliation") or {}
+        if not isinstance(reconciliation, dict):
+            logger.warning(
+                "Ignoring malformed worker reconciliation for %s:%s: %r",
+                image_id,
+                receipt_id,
+                reconciliation,
+            )
+            reconciliation = {}
         figures_agreeing = reconciliation.get("baseline_figures_agreeing")
         if not isinstance(figures_agreeing, int):
             figures_agreeing = None

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
@@ -442,6 +442,43 @@ def test_swift_single_pass_persists_worker_sections_and_line_items(
     assert line_items[0].source_model_source == "swift-worker-v1"
     # No summary exists at ingest, so the worker's own verdict rides along.
     assert line_items[0].reconciliation_status == "no-baseline"
+    # Tier-1 additive contract: the band text the item was parsed from,
+    # and the receipt-level graded verdict stamped onto every row.
+    assert line_items[0].raw_text == "ORGANIC 3.99"
+    assert line_items[0].baseline_figures_agreeing is None
+
+
+def test_worker_reconciliation_grade_is_stamped_on_rows(
+    aws_stack, swift_payload
+):
+    """A graded worker verdict lands on every persisted row.
+
+    The fixture's receipt reconciles to no-baseline (grade None); rewrite
+    the receipt-level verdict to a graded match and every row must carry
+    the grade — the same #1324 diagnostics a cloud recompute would stamp.
+    """
+    payload = json.loads(json.dumps(swift_payload))
+    for receipt in payload["receipts"]:
+        receipt["reconciliation"] = {
+            "status": "match",
+            "item_sum": 3.99,
+            "baseline": 3.99,
+            "baseline_source": "subtotal",
+            "baseline_figures_agreeing": 2,
+        }
+        for item in receipt["line_items"]:
+            item["reconciliation_status"] = "match"
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+
+    processor._process_swift_single_pass(payload, ocr_job, routing)
+
+    dynamo = DynamoClient(aws_stack)
+    line_items = dynamo.get_receipt_line_items_from_receipt(IMAGE_ID, 1)
+    assert line_items
+    for item in line_items:
+        assert item.reconciliation_status == "match"
+        assert item.baseline_figures_agreeing == 2
 
 
 def test_worker_structure_is_ignored_when_the_payload_omits_it(

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
@@ -486,6 +486,45 @@ def test_worker_reconciliation_grade_is_stamped_on_rows(
         assert item.baseline_figures_agreeing == 2
 
 
+@pytest.mark.parametrize(
+    "raw_grade,expected",
+    [
+        (True, None),
+        (0, None),
+        (4, None),
+        (2, 2),
+    ],
+)
+def test_out_of_band_reconciliation_grade_is_dropped(
+    aws_stack, swift_payload, raw_grade, expected
+):
+    """Only a real 1..3 grade is stamped; anything else becomes None.
+
+    ``ReceiptLineItem`` raises on a grade outside 1..3 and on ``True``
+    (bool subclasses int, so a naive isinstance check waves it through).
+    That exception fires inside the per-item try block, so an out-of-band
+    grade would silently cost the receipt every line item rather than just
+    the diagnostic field it came from.
+    """
+    payload = json.loads(json.dumps(swift_payload))
+    for receipt in payload["receipts"]:
+        receipt["reconciliation"] = {
+            "status": "match",
+            "baseline_figures_agreeing": raw_grade,
+        }
+
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+
+    processor._process_swift_single_pass(payload, ocr_job, routing)
+
+    dynamo = DynamoClient(aws_stack)
+    line_items = dynamo.get_receipt_line_items_from_receipt(IMAGE_ID, 1)
+    assert [item.name for item in line_items] == ["ORGANIC"]
+    for item in line_items:
+        assert item.baseline_figures_agreeing == expected
+
+
 def test_malformed_reconciliation_does_not_cost_the_worker_structure(
     aws_stack, swift_payload
 ):

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
@@ -440,12 +440,16 @@ def test_swift_single_pass_persists_worker_sections_and_line_items(
         "swift-worker-v1+line-items-blocks-v2"
     )
     assert line_items[0].source_model_source == "swift-worker-v1"
-    # No summary exists at ingest, so the worker's own verdict rides along.
-    assert line_items[0].reconciliation_status == "no-baseline"
+    # No summary exists at ingest, so the worker's own verdict rides along:
+    # the fixture's ``TOTAL 3.99`` anchors the grand-total baseline, which
+    # the 3.99 item sum matches.
+    assert line_items[0].reconciliation_status == "match"
     # Tier-1 additive contract: the band text the item was parsed from,
-    # and the receipt-level graded verdict stamped onto every row.
+    # and the receipt-level graded verdict stamped onto every row. The grade
+    # is 1 because the baseline came from the grand total with no tax line
+    # to corroborate it.
     assert line_items[0].raw_text == "ORGANIC 3.99"
-    assert line_items[0].baseline_figures_agreeing is None
+    assert line_items[0].baseline_figures_agreeing == 1
 
 
 def test_worker_reconciliation_grade_is_stamped_on_rows(
@@ -453,9 +457,10 @@ def test_worker_reconciliation_grade_is_stamped_on_rows(
 ):
     """A graded worker verdict lands on every persisted row.
 
-    The fixture's receipt reconciles to no-baseline (grade None); rewrite
-    the receipt-level verdict to a graded match and every row must carry
-    the grade — the same #1324 diagnostics a cloud recompute would stamp.
+    The fixture's receipt reconciles to a grand-total match (grade 1);
+    rewrite the receipt-level verdict to a subtotal-corroborated match and
+    every row must carry the new grade — the same #1324 diagnostics a cloud
+    recompute would stamp.
     """
     payload = json.loads(json.dumps(swift_payload))
     for receipt in payload["receipts"]:
@@ -479,6 +484,41 @@ def test_worker_reconciliation_grade_is_stamped_on_rows(
     for item in line_items:
         assert item.reconciliation_status == "match"
         assert item.baseline_figures_agreeing == 2
+
+
+def test_malformed_reconciliation_does_not_cost_the_worker_structure(
+    aws_stack, swift_payload
+):
+    """A non-object verdict is dropped, not raised.
+
+    ``reconciliation`` is optional diagnostics riding on an otherwise usable
+    payload. Reading it happens outside the per-entry try blocks, so a
+    truthy non-dict value used to abort the whole ingest — the receipt lost
+    its sections, its line items, and its routing decision over a field the
+    contract calls a bonus.
+    """
+    payload = json.loads(json.dumps(swift_payload))
+    for receipt in payload["receipts"]:
+        receipt["reconciliation"] = "corrupt"
+
+    processor = _processor(aws_stack)
+    ocr_job, routing = _seed_job(processor)
+
+    result = processor._process_swift_single_pass(payload, ocr_job, routing)
+
+    assert result["success"] is True
+    structure = result["per_receipt_data"][1]["worker_structure"]
+    assert structure["sections"] == 3
+    assert structure["line_items"] == 1
+
+    dynamo = DynamoClient(aws_stack)
+    assert {
+        section.section_type
+        for section in dynamo.get_receipt_sections_from_receipt(IMAGE_ID, 1)
+    } == {"ITEMS", "STOREFRONT", "TOTAL_LINE"}
+    line_items = dynamo.get_receipt_line_items_from_receipt(IMAGE_ID, 1)
+    assert [item.name for item in line_items] == ["ORGANIC"]
+    assert line_items[0].baseline_figures_agreeing is None
 
 
 def test_worker_structure_is_ignored_when_the_payload_omits_it(

--- a/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
+++ b/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
@@ -44,8 +44,7 @@ def _printed_subtotal(rows, lines, words) -> float | None:
             (
                 word
                 for word in words
-                if word.line_id in row_ids
-                and looks_like_receipt_amount(word.text)
+                if word.line_id in row_ids and looks_like_receipt_amount(word.text)
             ),
             key=lambda word: (
                 word.bounding_box["x"],
@@ -63,9 +62,7 @@ def _printed_subtotal(rows, lines, words) -> float | None:
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _PACKAGE_DIR = _SCRIPT_DIR.parent
 _REPO_ROOT = _PACKAGE_DIR.parent
-DEFAULT_INPUT = (
-    _REPO_ROOT / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
-)
+DEFAULT_INPUT = _REPO_ROOT / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
 DEFAULT_OUTPUT = (
     _PACKAGE_DIR
     / "Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json"
@@ -88,21 +85,13 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
     for receipt in fixture["receipts"]:
         lines, words = reconstruct(receipt)
         rows = build_receipt_rows(lines, words)
-        assignments = assign_row_sections(
-            rows, lines, model, receipt.get("merchant")
-        )
+        assignments = assign_row_sections(rows, lines, model, receipt.get("merchant"))
         sections = sections_from_assignments(assignments)
         items_section = next(
-            (
-                section
-                for section in sections
-                if section.section_type == "ITEMS"
-            ),
+            (section for section in sections if section.section_type == "ITEMS"),
             None,
         )
-        items_lines = (
-            set(items_section.line_ids) if items_section else set()
-        )
+        items_lines = set(items_section.line_ids) if items_section else set()
         subtotal = _printed_subtotal(rows, lines, words)
         # Mirrors buildOnDeviceReceiptStructure: a receipt that prints no
         # SUBTOTAL still prints a TOTAL, and the worker now anchors on it
@@ -130,17 +119,13 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                 items_lines,
                 sections,
                 rows,
-                current_row_ids=(
-                    items_section.row_ids if items_section else None
-                ),
+                current_row_ids=(items_section.row_ids if items_section else None),
             )
         if proposal:
             items_lines = set(proposal["line_ids"])
         # Decode WITH the scanned summary so the summary-figure filter
         # (#1320) is pinned exactly as the device runs it.
-        items, _ = extract_items(
-            receipt["words"], items_lines, summary=summary
-        )
+        items, _ = extract_items(receipt["words"], items_lines, summary=summary)
         rec = reconcile_detailed(
             [item for item in items if not item.get("is_discount")],
             summary,
@@ -155,8 +140,7 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                         "section_type": section.section_type,
                         "line_ids": (
                             sorted(items_lines)
-                            if proposal
-                            and section.section_type == "ITEMS"
+                            if proposal and section.section_type == "ITEMS"
                             else section.line_ids
                         ),
                     }
@@ -184,21 +168,16 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                     "item_sum": rec.item_sum,
                     "baseline": rec.baseline,
                     "baseline_source": rec.baseline_source,
-                    "baseline_figures_agreeing": (
-                        rec.baseline_figures_agreeing
-                    ),
+                    "baseline_figures_agreeing": (rec.baseline_figures_agreeing),
                 },
-                "should_reocr_items_zone": should_reocr_items_zone(
-                    items, subtotal
-                ),
+                "should_reocr_items_zone": should_reocr_items_zone(items, subtotal),
             }
         )
 
     # The golden set grows; derive the count instead of pinning it.
     if len(expected) != len(fixture["receipts"]):
         raise RuntimeError(
-            f"expected {len(fixture['receipts'])} receipts, "
-            f"got {len(expected)}"
+            f"expected {len(fixture['receipts'])} receipts, " f"got {len(expected)}"
         )
     return json.dumps(expected, indent=2) + "\n"
 

--- a/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
+++ b/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
@@ -16,7 +16,11 @@ from receipt_dynamo.amounts import (
 )
 from receipt_dynamo.entities.receipt_summary import find_printed_grand_total
 from receipt_upload.line_items.blocks import should_reocr_items_zone
-from receipt_upload.line_items.geometry import extract_items, reconcile
+from receipt_upload.line_items.geometry import (
+    extract_items,
+    propose_items_boundary_extension,
+    reconcile_detailed,
+)
 from receipt_upload.section_assignment import (
     assign_row_sections,
     load_prior_model,
@@ -88,15 +92,17 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
             rows, lines, model, receipt.get("merchant")
         )
         sections = sections_from_assignments(assignments)
-        items_lines = next(
+        items_section = next(
             (
-                set(section.line_ids)
+                section
                 for section in sections
                 if section.section_type == "ITEMS"
             ),
-            set(),
+            None,
         )
-        items, _ = extract_items(receipt["words"], items_lines)
+        items_lines = (
+            set(items_section.line_ids) if items_section else set()
+        )
         subtotal = _printed_subtotal(rows, lines, words)
         # Mirrors buildOnDeviceReceiptStructure: a receipt that prints no
         # SUBTOTAL still prints a TOTAL, and the worker now anchors on it
@@ -105,16 +111,41 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
         # exists, so this only reaches receipts that had no baseline at
         # all. The summary dict is always built, matching the Swift side,
         # which always constructs a LineItemSummary; an all-None dict
-        # reconciles to no-baseline exactly as `None` did.
+        # reconciles to no-baseline exactly as `None` did, and leaves the
+        # summary-figure filter a no-op.
         grand_total = find_printed_grand_total(words)
-        status, _, _ = reconcile(
-            [item for item in items if not item.get("is_discount")],
-            {
-                "subtotal": subtotal,
-                "tax": None,
-                "grand_total": grand_total,
-            },
+        summary = {
+            "subtotal": subtotal,
+            "tax": None,
+            "grand_total": grand_total,
+        }
+        # Mirrors the on-device zone-gap boundary extension (#1329): the
+        # proposal is accepted only on strict arithmetic improvement, so
+        # an already-matching zone always keeps its boundary.
+        proposal = None
+        if items_lines:
+            proposal = propose_items_boundary_extension(
+                receipt["words"],
+                summary,
+                items_lines,
+                sections,
+                rows,
+                current_row_ids=(
+                    items_section.row_ids if items_section else None
+                ),
+            )
+        if proposal:
+            items_lines = set(proposal["line_ids"])
+        # Decode WITH the scanned summary so the summary-figure filter
+        # (#1320) is pinned exactly as the device runs it.
+        items, _ = extract_items(
+            receipt["words"], items_lines, summary=summary
         )
+        rec = reconcile_detailed(
+            [item for item in items if not item.get("is_discount")],
+            summary,
+        )
+        status = rec.status
         expected.append(
             {
                 "image_id": receipt["image_id"],
@@ -122,7 +153,12 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                 "sections": [
                     {
                         "section_type": section.section_type,
-                        "line_ids": section.line_ids,
+                        "line_ids": (
+                            sorted(items_lines)
+                            if proposal
+                            and section.section_type == "ITEMS"
+                            else section.line_ids
+                        ),
                     }
                     for section in sections
                 ],
@@ -137,11 +173,21 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                         "name_quality": item.get("name_quality") or "ok",
                         "line_ids": item["line_ids"],
                         "reconciliation_status": status,
+                        "raw_text": item.get("raw_text") or "",
                     }
                     for index, item in enumerate(items)
                 ],
                 "printed_subtotal": subtotal,
                 "reconciliation_status": status,
+                "reconciliation": {
+                    "status": rec.status,
+                    "item_sum": rec.item_sum,
+                    "baseline": rec.baseline,
+                    "baseline_source": rec.baseline_source,
+                    "baseline_figures_agreeing": (
+                        rec.baseline_figures_agreeing
+                    ),
+                },
                 "should_reocr_items_zone": should_reocr_items_zone(
                     items, subtotal
                 ),

--- a/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
+++ b/receipt_ocr_swift/Scripts/generate_receipt_structure_parity.py
@@ -44,7 +44,8 @@ def _printed_subtotal(rows, lines, words) -> float | None:
             (
                 word
                 for word in words
-                if word.line_id in row_ids and looks_like_receipt_amount(word.text)
+                if word.line_id in row_ids
+                and looks_like_receipt_amount(word.text)
             ),
             key=lambda word: (
                 word.bounding_box["x"],
@@ -62,7 +63,9 @@ def _printed_subtotal(rows, lines, words) -> float | None:
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _PACKAGE_DIR = _SCRIPT_DIR.parent
 _REPO_ROOT = _PACKAGE_DIR.parent
-DEFAULT_INPUT = _REPO_ROOT / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
+DEFAULT_INPUT = (
+    _REPO_ROOT / "receipt_upload/tests/fixtures/line_items_golden_ocr.json"
+)
 DEFAULT_OUTPUT = (
     _PACKAGE_DIR
     / "Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json"
@@ -85,10 +88,16 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
     for receipt in fixture["receipts"]:
         lines, words = reconstruct(receipt)
         rows = build_receipt_rows(lines, words)
-        assignments = assign_row_sections(rows, lines, model, receipt.get("merchant"))
+        assignments = assign_row_sections(
+            rows, lines, model, receipt.get("merchant")
+        )
         sections = sections_from_assignments(assignments)
         items_section = next(
-            (section for section in sections if section.section_type == "ITEMS"),
+            (
+                section
+                for section in sections
+                if section.section_type == "ITEMS"
+            ),
             None,
         )
         items_lines = set(items_section.line_ids) if items_section else set()
@@ -119,13 +128,17 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                 items_lines,
                 sections,
                 rows,
-                current_row_ids=(items_section.row_ids if items_section else None),
+                current_row_ids=(
+                    items_section.row_ids if items_section else None
+                ),
             )
         if proposal:
             items_lines = set(proposal["line_ids"])
         # Decode WITH the scanned summary so the summary-figure filter
         # (#1320) is pinned exactly as the device runs it.
-        items, _ = extract_items(receipt["words"], items_lines, summary=summary)
+        items, _ = extract_items(
+            receipt["words"], items_lines, summary=summary
+        )
         rec = reconcile_detailed(
             [item for item in items if not item.get("is_discount")],
             summary,
@@ -168,16 +181,21 @@ def generate(input_path: Path = DEFAULT_INPUT) -> str:
                     "item_sum": rec.item_sum,
                     "baseline": rec.baseline,
                     "baseline_source": rec.baseline_source,
-                    "baseline_figures_agreeing": (rec.baseline_figures_agreeing),
+                    "baseline_figures_agreeing": (
+                        rec.baseline_figures_agreeing
+                    ),
                 },
-                "should_reocr_items_zone": should_reocr_items_zone(items, subtotal),
+                "should_reocr_items_zone": should_reocr_items_zone(
+                    items, subtotal
+                ),
             }
         )
 
     # The golden set grows; derive the count instead of pinning it.
     if len(expected) != len(fixture["receipts"]):
         raise RuntimeError(
-            f"expected {len(fixture['receipts'])} receipts, " f"got {len(expected)}"
+            f"expected {len(fixture['receipts'])} receipts, "
+            f"got {len(expected)}"
         )
     return json.dumps(expected, indent=2) + "\n"
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -59,6 +59,9 @@ public struct DecodedLineItem: Sendable {
     /// `name_quality`); nil otherwise.
     public var nameQuality: String?
     public var lineIds: [Int]
+    /// The band text the item was parsed from (Python `raw_text`).
+    /// Diagnostic provenance, not compared by the parity gate.
+    public var rawText: String = ""
 }
 
 /// Template -> role prior entry (assets/block_role_priors_v2.json).
@@ -1121,7 +1124,8 @@ public func extractLineItems(
             unitPrice: p.unitPrice,
             isDiscount: p.isDiscount,
             nameQuality: p.nameQuality,
-            lineIds: p.lineIds
+            lineIds: p.lineIds,
+            rawText: p.rawText
         )
     }
 }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptDetection.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptDetection.swift
@@ -136,6 +136,19 @@ public struct ReceiptOutput: Codable {
     /// section and reconciled against its own printed subtotal.
     public let lineItems: [ReceiptLineItemPayload]
 
+    /// The printed SUBTOTAL the worker scanned off the paper, when one
+    /// exists. Optional: absent on payloads from earlier worker builds.
+    public let printedSubtotal: Double?
+
+    /// The worker's own re-OCR verdict for the ITEMS zone (items decoded
+    /// but missing the printed subtotal by more than the near band).
+    /// Previously computed on device and discarded.
+    public let shouldReocrItemsZone: Bool?
+
+    /// The graded receipt-level reconciliation verdict (#1324): status,
+    /// item sum, baseline, baseline source and figure-agreement grade.
+    public let reconciliation: ReceiptReconciliationPayload?
+
     /// True when this crop probably contains multiple overlapping receipts that
     /// couldn't be confidently split — flag for human review.
     public let needsReview: Bool
@@ -173,6 +186,9 @@ public struct ReceiptOutput: Codable {
         self.barcodes = barcodes
         self.sections = sections ?? structure?.sections ?? []
         self.lineItems = lineItems ?? structure?.lineItems ?? []
+        self.printedSubtotal = structure?.printedSubtotal
+        self.shouldReocrItemsZone = structure?.shouldReocrItemsZone
+        self.reconciliation = structure?.reconciliation
         self.needsReview = needsReview
     }
 
@@ -205,6 +221,9 @@ public struct ReceiptOutput: Codable {
         self.barcodes = barcodes
         self.sections = sections ?? structure?.sections ?? []
         self.lineItems = lineItems ?? structure?.lineItems ?? []
+        self.printedSubtotal = structure?.printedSubtotal
+        self.shouldReocrItemsZone = structure?.shouldReocrItemsZone
+        self.reconciliation = structure?.reconciliation
         self.needsReview = processed.needsReview
     }
 
@@ -220,6 +239,9 @@ public struct ReceiptOutput: Codable {
         case barcodes
         case sections
         case lineItems = "line_items"
+        case printedSubtotal = "printed_subtotal"
+        case shouldReocrItemsZone = "should_reocr_items_zone"
+        case reconciliation
         case needsReview = "needs_review"
     }
 }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
@@ -50,6 +50,29 @@ public struct ReceiptLineItemPayload: Codable, Sendable, Equatable {
     public let reconciliationStatus: String
     public let modelSource: String
     public let extractorVersion: String
+    /// The band text the item was parsed from (`ReceiptLineItem.raw_text`).
+    /// Optional so payloads from earlier worker builds still decode.
+    public let rawText: String?
+
+    public init(
+        itemIndex: Int, name: String, price: Double, quantity: Double?,
+        unitPrice: Double?, isDiscount: Bool, nameQuality: String,
+        lineIds: [Int], reconciliationStatus: String, modelSource: String,
+        extractorVersion: String, rawText: String? = nil
+    ) {
+        self.itemIndex = itemIndex
+        self.name = name
+        self.price = price
+        self.quantity = quantity
+        self.unitPrice = unitPrice
+        self.isDiscount = isDiscount
+        self.nameQuality = nameQuality
+        self.lineIds = lineIds
+        self.reconciliationStatus = reconciliationStatus
+        self.modelSource = modelSource
+        self.extractorVersion = extractorVersion
+        self.rawText = rawText
+    }
 
     enum CodingKeys: String, CodingKey {
         case itemIndex = "item_index"
@@ -63,6 +86,33 @@ public struct ReceiptLineItemPayload: Codable, Sendable, Equatable {
         case reconciliationStatus = "reconciliation_status"
         case modelSource = "model_source"
         case extractorVersion = "extractor_version"
+        case rawText = "raw_text"
+    }
+}
+
+/// JSON contract for the receipt-level reconciliation verdict: the #1324
+/// graded result the worker always computed but never shipped.
+public struct ReceiptReconciliationPayload: Codable, Sendable, Equatable {
+    public let status: String
+    public let itemSum: Double?
+    public let baseline: Double?
+    public let baselineSource: String?
+    public let baselineFiguresAgreeing: Int?
+
+    public init(_ result: ReconcileResult) {
+        self.status = result.status
+        self.itemSum = result.itemSum
+        self.baseline = result.baseline
+        self.baselineSource = result.baselineSource
+        self.baselineFiguresAgreeing = result.baselineFiguresAgreeing
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case itemSum = "item_sum"
+        case baseline
+        case baselineSource = "baseline_source"
+        case baselineFiguresAgreeing = "baseline_figures_agreeing"
     }
 }
 
@@ -75,6 +125,8 @@ public struct OnDeviceReceiptStructure: Sendable, Equatable {
     public let printedSubtotal: Double?
     public let reconciliationStatus: String
     public let shouldReocrItemsZone: Bool
+    /// The full graded verdict behind `reconciliationStatus`.
+    public let reconciliation: ReceiptReconciliationPayload
 }
 
 private enum ReceiptStructureRegex {
@@ -150,10 +202,12 @@ public func buildOnDeviceReceiptStructure(
     lines: [SectionLine], merchantName: String? = nil
 ) throws -> OnDeviceReceiptStructure {
     guard !lines.isEmpty else {
+        let empty = reconcileLineItemsDetailed(items: [], summary: nil)
         return OnDeviceReceiptStructure(
             sections: [], lineItems: [], printedSubtotal: nil,
             reconciliationStatus: "no-baseline",
-            shouldReocrItemsZone: false
+            shouldReocrItemsZone: false,
+            reconciliation: ReceiptReconciliationPayload(empty)
         )
     }
     let rows = buildReceiptRows(lines: lines)
@@ -164,7 +218,7 @@ public func buildOnDeviceReceiptStructure(
             merchantName: merchantName
         )
     )
-    let sections = predictions.map { section in
+    var sections = predictions.map { section in
         ReceiptSectionPayload(
             sectionType: section.sectionType,
             lineIds: section.lineIds,
@@ -175,7 +229,7 @@ public func buildOnDeviceReceiptStructure(
         )
     }
 
-    let itemsLineIds = Set(
+    var itemsLineIds = Set(
         sections.first { $0.sectionType == "ITEMS" }?.lineIds ?? []
     )
     let zoneWords = lines.flatMap(\.words).map { word in
@@ -188,8 +242,6 @@ public func buildOnDeviceReceiptStructure(
             h: word.boundingBox.height
         )
     }
-    let decoded = itemsLineIds.isEmpty
-        ? [] : extractLineItems(words: zoneWords, zoneLineIds: itemsLineIds)
     let printedSubtotal = findPrintedSubtotal(rows: rows, lines: lines)
     // A receipt that prints no SUBTOTAL still prints a TOTAL, and until
     // now the worker ignored it: `PrintedTotals` (the #1321 port of
@@ -207,9 +259,52 @@ public func buildOnDeviceReceiptStructure(
     let printedGrandTotal = PrintedTotals.grandTotal(
         words: lines.flatMap(\.words).map(PrintedTotalWord.init)
     )
-    let reconciliation = reconcileLineItems(
-        items: decoded.filter { !$0.isDiscount },
-        subtotal: printedSubtotal, grandTotal: printedGrandTotal, tax: nil
+    // Always construct the summary: an all-nil summary reconciles to
+    // no-baseline exactly as nil did, and the summary-figure filter is a
+    // no-op without figures, so subtotal-less receipts are unaffected.
+    let summary = LineItemSummary(
+        subtotal: printedSubtotal, tax: nil, grandTotal: printedGrandTotal
+    )
+
+    // Zone-gap boundary extension (#1329), previously cloud-only: the
+    // proposal is accepted only when the arithmetic strictly improves
+    // (smaller |delta| AND better status), so against an already-matching
+    // zone it always returns nil. The widened ITEMS section ships in the
+    // payload, mirroring how the cloud path persists its own extension.
+    if !itemsLineIds.isEmpty,
+        let proposal = proposeItemsBoundaryExtension(
+            words: zoneWords,
+            summary: summary,
+            currentLineIds: itemsLineIds,
+            sections: sections.map(BoundarySection.init),
+            rows: rows.map(BoundaryRow.init),
+            currentRowIds: sections.first { $0.sectionType == "ITEMS" }?
+                .rowIds
+        )
+    {
+        itemsLineIds = Set(proposal.lineIds)
+        sections = sections.map { section in
+            guard section.sectionType == "ITEMS" else { return section }
+            return ReceiptSectionPayload(
+                sectionType: section.sectionType,
+                lineIds: proposal.lineIds,
+                rowIds: proposal.rowIds ?? section.rowIds,
+                confidence: section.confidence,
+                modelSource: section.modelSource,
+                extractorVersion: section.extractorVersion
+            )
+        }
+    }
+
+    // Decode WITH the scanned summary so the summary-figure filter
+    // (#1320) runs on device exactly as it does in the cloud recompute.
+    let decoded = itemsLineIds.isEmpty
+        ? []
+        : extractLineItems(
+            words: zoneWords, zoneLineIds: itemsLineIds, summary: summary
+        )
+    let reconciliation = reconcileLineItemsDetailed(
+        items: decoded.filter { !$0.isDiscount }, summary: summary
     )
     let lineItems = decoded.enumerated().map { index, item in
         ReceiptLineItemPayload(
@@ -223,7 +318,8 @@ public func buildOnDeviceReceiptStructure(
             lineIds: item.lineIds,
             reconciliationStatus: reconciliation.status,
             modelSource: swiftWorkerModelSource,
-            extractorVersion: swiftWorkerExtractorVersion
+            extractorVersion: swiftWorkerExtractorVersion,
+            rawText: item.rawText
         )
     }
     return OnDeviceReceiptStructure(
@@ -233,7 +329,8 @@ public func buildOnDeviceReceiptStructure(
         reconciliationStatus: reconciliation.status,
         shouldReocrItemsZone: shouldReocrItemsZone(
             items: decoded, printedSubtotal: printedSubtotal
-        )
+        ),
+        reconciliation: ReceiptReconciliationPayload(reconciliation)
     )
 }
 

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -26,7 +26,8 @@
           9,
           11
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Rockenwagner French Loaf $4.99 F"
       },
       {
         "item_index": 1,
@@ -40,11 +41,19 @@
           8,
           10
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Clorox Disinfecting Bleac... $8.99 T"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -106,7 +115,8 @@
           47,
           48
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "i: IFS 3 LB. 5.79 7.49"
       },
       {
         "item_index": 1,
@@ -127,7 +137,8 @@
           43,
           44
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "E 1391546 29827 AHI BAGEL TUNA CH 38.40 7.99"
       },
       {
         "item_index": 2,
@@ -143,7 +154,8 @@
           35,
           36
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1113319 15' S COLICORNIA MONDELUKE 9.49 1.89"
       },
       {
         "item_index": 3,
@@ -160,7 +172,8 @@
           31,
           32
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "003 137 003 STRAWBERRIES SEAWEED SALJ 6.99 1.99"
       },
       {
         "item_index": 4,
@@ -177,7 +190,8 @@
           26,
           28
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "or 57554 '917 BLUEBERRI! S&P PISTACH 17.49 5.79"
       },
       {
         "item_index": 5,
@@ -194,7 +208,8 @@
           22,
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "709616 25595 COCKTAIL BUFALA MOZZ TOM 14.69 6.99"
       },
       {
         "item_index": 6,
@@ -211,7 +226,8 @@
           18,
           19
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1055663 1131563 CHICKN HNY RSTD SALAD MIX 15.49 8.49"
       },
       {
         "item_index": 7,
@@ -227,11 +243,19 @@
           14,
           15
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "10'8249 ORG HORIZON ATAULFO 12.99 6.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -261,11 +285,19 @@
           11,
           15
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "E 33977 BEEF FLANK 46.28"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -300,11 +332,19 @@
           37,
           40
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "BUTTER CHARDONNAY 17.99 T"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -334,7 +374,8 @@
         "line_ids": [
           19
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6.80"
       },
       {
         "item_index": 1,
@@ -348,7 +389,8 @@
           10,
           18
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Reg Chocolate Shk 3.05"
       },
       {
         "item_index": 2,
@@ -362,11 +404,19 @@
           7,
           17
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Hamburger 3.75"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -397,7 +447,8 @@
           13,
           21
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Animal Fry 4.75"
       },
       {
         "item_index": 1,
@@ -412,11 +463,19 @@
           12,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "5 Meat Patty 9.75"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -464,7 +523,8 @@
           23,
           33
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Ponzu Sauce 1.00"
       },
       {
         "item_index": 1,
@@ -479,7 +539,8 @@
           22,
           32
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Steamed White Rice 3.00"
       },
       {
         "item_index": 2,
@@ -494,7 +555,8 @@
           21,
           31
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Albacore Sushi 10.00"
       },
       {
         "item_index": 3,
@@ -509,7 +571,8 @@
           20,
           30
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Japanese Scallop Sushi 12.00"
       },
       {
         "item_index": 4,
@@ -524,7 +587,8 @@
           19,
           29
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Mango Sticky Rice 14.00"
       },
       {
         "item_index": 5,
@@ -539,7 +603,8 @@
           17,
           28
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Crispy Pork Belly Basil 20.00"
       },
       {
         "item_index": 6,
@@ -554,11 +619,19 @@
           14,
           27
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Large Bottled Beer 13.00"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -588,7 +661,8 @@
           8,
           12
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "OLIPOP SPRKL TONIC 1.99 F"
       },
       {
         "item_index": 1,
@@ -602,11 +676,19 @@
           7,
           11
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "OL IPOP GRAPE 2.49 F"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -641,11 +723,19 @@
           14,
           15
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG A2/A2 6% FAT MLK 7.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -677,7 +767,8 @@
           19,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "SOUR CREAM 2.79"
       },
       {
         "item_index": 1,
@@ -691,7 +782,8 @@
           15,
           17
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "BROCCOLI FLORETS 3.49"
       },
       {
         "item_index": 2,
@@ -705,11 +797,19 @@
           14,
           16
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1LB BAG BABY CARROT 1.29"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -743,7 +843,8 @@
           22,
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "LARGE ALFRESCO EGGS 10.99"
       },
       {
         "item_index": 1,
@@ -757,7 +858,8 @@
           17,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORGANIC GREEN ONIONS 1.29"
       },
       {
         "item_index": 2,
@@ -771,7 +873,8 @@
           16,
           19
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG GINGER ROOT 7.99"
       },
       {
         "item_index": 3,
@@ -785,11 +888,19 @@
           15,
           18
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG 3 CNT GARLIC 2.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -840,7 +951,8 @@
           18,
           27
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "GUAVA NECTAR JUICE ORG 3 $3.99"
       },
       {
         "item_index": 1,
@@ -854,7 +966,8 @@
           17,
           26
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MANGO NECTAR JUICE ORG 6 $5.49"
       },
       {
         "item_index": 2,
@@ -868,7 +981,8 @@
           16,
           25
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MULTI-FLORAL AND CLOVER $3.99"
       },
       {
         "item_index": 3,
@@ -882,7 +996,8 @@
           15,
           24
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "SUPER SPINACH SALAD $4.49"
       },
       {
         "item_index": 4,
@@ -895,7 +1010,8 @@
         "line_ids": [
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "$8.98"
       },
       {
         "item_index": 5,
@@ -909,7 +1025,8 @@
           12,
           22
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "SALAD CHICKEN APPLE WALD $5.99"
       },
       {
         "item_index": 6,
@@ -923,7 +1040,8 @@
           10,
           21
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "EGG BITES UNEXPECTED CHE $7.58"
       },
       {
         "item_index": 7,
@@ -937,7 +1055,8 @@
           9,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MILK QUART WHOLE $1.79"
       },
       {
         "item_index": 8,
@@ -951,11 +1070,19 @@
           8,
           19
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "HALF & HALF PINT $1.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -1017,7 +1144,8 @@
           13,
           32
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "203600096 GG WATER NF P $3.59"
       },
       {
         "item_index": 1,
@@ -1033,7 +1161,8 @@
           30,
           31
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "210100025 GG BACON NF $6 1.79"
       },
       {
         "item_index": 2,
@@ -1048,7 +1177,8 @@
           26,
           28
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "211350249 CUT FRUIT NF $5.99"
       },
       {
         "item_index": 3,
@@ -1064,7 +1194,8 @@
           25,
           27
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "266080008 BERRIES NF $5 1.89"
       },
       {
         "item_index": 4,
@@ -1079,7 +1210,8 @@
           22,
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "266080007 BERRIES NF $6.99"
       },
       {
         "item_index": 5,
@@ -1094,7 +1226,8 @@
           20,
           21
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "266085239 BERRIES NF $5.69"
       },
       {
         "item_index": 6,
@@ -1109,11 +1242,19 @@
           18,
           19
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "266087500 BERRIES NF $6.79"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -1138,6 +1279,13 @@
     "line_items": [],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -1219,7 +1367,8 @@
           73,
           74
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.64"
       },
       {
         "item_index": 1,
@@ -1235,7 +1384,8 @@
           70,
           71
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "764666103221 15/8CRDWSC5# <A> 25.98"
       },
       {
         "item_index": 2,
@@ -1250,7 +1400,8 @@
           66,
           67
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "764666105225 15/8FNDWSC1# <A* 5.97"
       },
       {
         "item_index": 3,
@@ -1266,7 +1417,8 @@
           63,
           64
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -1.27"
       },
       {
         "item_index": 4,
@@ -1281,7 +1433,8 @@
           59,
           60
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "039645112625 20#WATERSTOP <A> 25.45"
       },
       {
         "item_index": 5,
@@ -1298,7 +1451,8 @@
           56,
           57
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.12"
       },
       {
         "item_index": 6,
@@ -1314,7 +1468,8 @@
           51,
           52
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "2@7.97 15.94"
       },
       {
         "item_index": 7,
@@ -1328,7 +1483,8 @@
           45,
           46
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "3@16.98 50.94"
       },
       {
         "item_index": 8,
@@ -1342,7 +1498,8 @@
           40,
           41
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "820909095569 CAULK GUN =A> 19.98"
       },
       {
         "item_index": 9,
@@ -1356,7 +1513,8 @@
           37,
           38
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "037083014143 TITEBOND3 16 <A> 9.98"
       },
       {
         "item_index": 10,
@@ -1371,7 +1529,8 @@
           35,
           36
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "208.78 17.56"
       },
       {
         "item_index": 11,
@@ -1387,7 +1546,8 @@
           32,
           33
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "2@15.51 31.02"
       },
       {
         "item_index": 12,
@@ -1402,7 +1562,8 @@
           26,
           27
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "307.62 22.86"
       },
       {
         "item_index": 13,
@@ -1418,7 +1579,8 @@
           23,
           24
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "3@15.28 45.84"
       },
       {
         "item_index": 14,
@@ -1434,7 +1596,8 @@
           19,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "751361004144 10'-25GA STD <A= 14.98"
       },
       {
         "item_index": 15,
@@ -1448,7 +1611,8 @@
           14,
           15
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "000516315018 JT COMPOUND <A> 12.52"
       },
       {
         "item_index": 16,
@@ -1463,11 +1627,19 @@
           12,
           13
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "2014.61 29.22"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -1563,7 +1735,8 @@
           71,
           86
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.60"
       },
       {
         "item_index": 1,
@@ -1576,7 +1749,8 @@
         "line_ids": [
           68
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $7.34/2"
       },
       {
         "item_index": 2,
@@ -1591,7 +1765,8 @@
           67,
           69
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "203.86 7.72"
       },
       {
         "item_index": 3,
@@ -1605,7 +1780,8 @@
           64,
           65
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $4.00/2"
       },
       {
         "item_index": 4,
@@ -1620,7 +1796,8 @@
           62,
           63
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "202.11 4.22"
       },
       {
         "item_index": 5,
@@ -1637,7 +1814,8 @@
           59,
           60
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.53"
       },
       {
         "item_index": 6,
@@ -1652,7 +1830,8 @@
           54,
           55
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "045242517824 5/8X8MX4 <A= 17.77"
       },
       {
         "item_index": 7,
@@ -1667,7 +1846,8 @@
           51,
           52
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.90"
       },
       {
         "item_index": 8,
@@ -1680,7 +1860,8 @@
         "line_ids": [
           48
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $44.01/3"
       },
       {
         "item_index": 9,
@@ -1696,7 +1877,8 @@
           47,
           49
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "3@14.97 44.91"
       },
       {
         "item_index": 10,
@@ -1713,7 +1895,8 @@
           43,
           44
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.82"
       },
       {
         "item_index": 11,
@@ -1728,7 +1911,8 @@
           38,
           39
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "811664023362 FINGERJOINT \u00abA> 10.97"
       },
       {
         "item_index": 12,
@@ -1741,7 +1925,8 @@
         "line_ids": [
           36
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $29.30/5"
       },
       {
         "item_index": 13,
@@ -1757,7 +1942,8 @@
           34,
           35
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "505.98 29.90"
       },
       {
         "item_index": 14,
@@ -1773,7 +1959,8 @@
           30,
           31
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "000516311010 LT COMPOUND <A> 14.61"
       },
       {
         "item_index": 15,
@@ -1788,7 +1975,8 @@
           26,
           27
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "034481193463 ADJUSTABOX3 <A\u00bb 13.40"
       },
       {
         "item_index": 16,
@@ -1804,7 +1992,8 @@
           23,
           24
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "000516221654 20 FAST SET <A> 15.51"
       },
       {
         "item_index": 17,
@@ -1818,7 +2007,8 @@
           19,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "5@0.05 0.25N"
       },
       {
         "item_index": 18,
@@ -1833,7 +2023,8 @@
           15,
           17
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "0000-999-735 CA LBR FEE <A,U\u00bb 0.10N"
       },
       {
         "item_index": 19,
@@ -1847,7 +2038,8 @@
           11,
           12
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "0000-999-735 CA_LBR FEE \u00abA, U= 0.38N"
       },
       {
         "item_index": 20,
@@ -1862,11 +2054,19 @@
           9,
           10
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "813952015882 MELAMINE \u2264A> 38.97"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2016,7 +2216,8 @@
           122,
           124
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pricing -0.26"
       },
       {
         "item_index": 1,
@@ -2032,7 +2233,8 @@
           117,
           118
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.54"
       },
       {
         "item_index": 2,
@@ -2048,7 +2250,8 @@
           113,
           114
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "077089375060 6X3/4 IN MIN =A= 6.37"
       },
       {
         "item_index": 3,
@@ -2063,7 +2266,8 @@
           109,
           110
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "077089143669 6X3/8 6 PK <A- 11.54"
       },
       {
         "item_index": 4,
@@ -2079,7 +2283,8 @@
           106,
           107
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "DW Backwall BOGO -199.00"
       },
       {
         "item_index": 5,
@@ -2095,7 +2300,8 @@
           102,
           103
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "885911677202 20-VOLT MAX <A> 199.00"
       },
       {
         "item_index": 6,
@@ -2110,7 +2316,8 @@
           98,
           99
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "885911881135 20-VOLT MAX <A,S\u00bb 299.00"
       },
       {
         "item_index": 7,
@@ -2124,7 +2331,8 @@
           95,
           96
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -1.96"
       },
       {
         "item_index": 8,
@@ -2139,7 +2347,8 @@
           92,
           94
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "2@10.97 21.94"
       },
       {
         "item_index": 9,
@@ -2153,7 +2362,8 @@
           89,
           90
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $72.32/8"
       },
       {
         "item_index": 10,
@@ -2168,7 +2378,8 @@
           87,
           88
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "8@9.23 73.84"
       },
       {
         "item_index": 11,
@@ -2185,7 +2396,8 @@
           84,
           85
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -7.89"
       },
       {
         "item_index": 12,
@@ -2201,7 +2413,8 @@
           79,
           80
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "052063061313 9 IN. DOWN S <A* 44.97"
       },
       {
         "item_index": 13,
@@ -2216,7 +2429,8 @@
           75,
           76
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "052063059891 DOWNSPT ADPT <A> 4.74"
       },
       {
         "item_index": 14,
@@ -2229,7 +2443,8 @@
         "line_ids": [
           73
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $10.22/2"
       },
       {
         "item_index": 15,
@@ -2243,7 +2458,8 @@
           71,
           72
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "205.27 10.54"
       },
       {
         "item_index": 16,
@@ -2256,7 +2472,8 @@
         "line_ids": [
           68
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "MAX REFUND VALUE $27.60/6"
       },
       {
         "item_index": 17,
@@ -2272,7 +2489,8 @@
           66,
           67
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6@4.74 28.44"
       },
       {
         "item_index": 18,
@@ -2288,7 +2506,8 @@
           60,
           63
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "052063402482 CHL COUPLG <A> 5.47"
       },
       {
         "item_index": 19,
@@ -2305,7 +2524,8 @@
           55,
           56
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Pro Xtra Preferred Pricing -0.27"
       },
       {
         "item_index": 20,
@@ -2323,7 +2543,8 @@
           50,
           51
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "887480310610 MACH SCR <A> 1.38"
       },
       {
         "item_index": 21,
@@ -2339,7 +2560,8 @@
           44,
           45
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "811108037139 ASSORTED (YE <A> 14.48"
       },
       {
         "item_index": 22,
@@ -2354,7 +2576,8 @@
           40,
           41
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "304.48 13.44"
       },
       {
         "item_index": 23,
@@ -2370,7 +2593,8 @@
           37,
           38
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "047034115737 5 GA STR <A> 4.27"
       },
       {
         "item_index": 24,
@@ -2384,7 +2608,8 @@
           33,
           34
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "NLP Savings $0.50"
       },
       {
         "item_index": 25,
@@ -2399,7 +2624,8 @@
           31,
           32
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "084305355546 HOMER BUCKET <A> 3.98"
       },
       {
         "item_index": 26,
@@ -2413,7 +2639,8 @@
           28,
           29
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "NLP Savings $0.00"
       },
       {
         "item_index": 27,
@@ -2428,7 +2655,8 @@
           22,
           24
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "NLP Savings $0.00"
       },
       {
         "item_index": 28,
@@ -2442,7 +2670,8 @@
           20,
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "200.10 0.20N"
       },
       {
         "item_index": 29,
@@ -2458,7 +2687,8 @@
           17,
           18
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "200.98 1.96"
       },
       {
         "item_index": 30,
@@ -2475,11 +2705,19 @@
           13,
           14
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "885911724890 20-VOLT MAX =A , Sa 299.00"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2526,7 +2764,8 @@
           20,
           24
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 Uitimate Egg $12.75"
       },
       {
         "item_index": 1,
@@ -2542,11 +2781,19 @@
           17,
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1 ABC Burger[Beel! $13.25"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2590,7 +2837,8 @@
         "line_ids": [
           24
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "$4.49"
       },
       {
         "item_index": 1,
@@ -2604,7 +2852,8 @@
           13,
           23
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "SPICY SPUDS $4.49"
       },
       {
         "item_index": 2,
@@ -2618,7 +2867,8 @@
           12,
           22
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "R-ARUGULA LEMON BASIL CO $3,99"
       },
       {
         "item_index": 3,
@@ -2632,7 +2882,8 @@
           11,
           21
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "BEANS GREEN ORGANIC 1LB $3.29"
       },
       {
         "item_index": 4,
@@ -2646,7 +2897,8 @@
           10,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "CHICKEN GYOZA $3.99"
       },
       {
         "item_index": 5,
@@ -2660,11 +2912,19 @@
           9,
           19
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "CHICKEN GYOZA $3.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2708,7 +2968,8 @@
           13,
           16
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "12 Wings 18.49"
       },
       {
         "item_index": 1,
@@ -2722,11 +2983,19 @@
           11,
           15
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Water (2 80.00) 0.00"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2752,11 +3021,19 @@
         "line_ids": [
           12
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "79936653722 AMAZON 50.00"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2788,11 +3065,19 @@
           14,
           16
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "1258700020 GLAD CLING WRAP 5.99 6.99 T"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2846,7 +3131,8 @@
           27,
           28
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6164 1 6.98 6.98"
       },
       {
         "item_index": 1,
@@ -2862,7 +3148,8 @@
           25,
           26
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6164 1 6.98 6.98"
       },
       {
         "item_index": 2,
@@ -2877,11 +3164,19 @@
           19,
           20
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6164 6.98 6.98"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -2953,7 +3248,8 @@
           46,
           58
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6164 1 6.98 6.98"
       },
       {
         "item_index": 1,
@@ -2969,7 +3265,8 @@
           45,
           57
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6164 6.98 6.98"
       },
       {
         "item_index": 2,
@@ -2986,7 +3283,8 @@
           44,
           56
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6163 1 6.98 6.98"
       },
       {
         "item_index": 3,
@@ -3003,7 +3301,8 @@
           43,
           55
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6163 1 6.98 6.98"
       },
       {
         "item_index": 4,
@@ -3020,7 +3319,8 @@
           42,
           54
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "7224 1 3.97 3.97"
       },
       {
         "item_index": 5,
@@ -3037,7 +3337,8 @@
           41,
           53
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "7224 1 3.97 3.97"
       },
       {
         "item_index": 6,
@@ -3053,7 +3354,8 @@
           40,
           52
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "8105 1 7.98 7.98"
       },
       {
         "item_index": 7,
@@ -3071,11 +3373,19 @@
           38,
           51
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "8108 1 18.98 18.98"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3132,7 +3442,8 @@
           28,
           37
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "8129 14.98 14.98"
       },
       {
         "item_index": 1,
@@ -3148,7 +3459,8 @@
           27,
           36
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "8129 1 14.98 14.98"
       },
       {
         "item_index": 2,
@@ -3164,7 +3476,8 @@
           25,
           35
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6255 1 44.98 44.98"
       },
       {
         "item_index": 3,
@@ -3183,11 +3496,19 @@
           33,
           34
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "6255 1 44.98 44.98"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3228,11 +3549,19 @@
           6,
           7
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "HOT BAR $10.55 T"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3242,6 +3571,13 @@
     "line_items": [],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3325,7 +3661,8 @@
           75,
           99
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORGANIC SOUR CREAM 3.29 F"
       },
       {
         "item_index": 1,
@@ -3340,7 +3677,8 @@
           74,
           98
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG LRG GRADE A EGGS 11.99 F"
       },
       {
         "item_index": 2,
@@ -3355,7 +3693,8 @@
           73,
           97
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG A2/A2 6% FAT MLK 7.99 F"
       },
       {
         "item_index": 3,
@@ -3370,7 +3709,8 @@
           72,
           96
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "KOREAN BBQ SAUCE 6.99 F"
       },
       {
         "item_index": 4,
@@ -3384,7 +3724,8 @@
           52,
           71
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "*CRV FS 05 0.10"
       },
       {
         "item_index": 5,
@@ -3399,7 +3740,8 @@
           70,
           95
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "100% COCONUT H20 WIT 4.00 F"
       },
       {
         "item_index": 6,
@@ -3414,7 +3756,8 @@
           69,
           94
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "WHITE ONIONS 1.59 F"
       },
       {
         "item_index": 7,
@@ -3429,7 +3772,8 @@
           68,
           93
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "RED BELL PEPPERS 3.00 F"
       },
       {
         "item_index": 8,
@@ -3444,7 +3788,8 @@
           67,
           92
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORGANIC GREEN ONIONS 1.29 F"
       },
       {
         "item_index": 9,
@@ -3459,7 +3804,8 @@
           66,
           91
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG SLICED CRIMINI 6.98 F"
       },
       {
         "item_index": 10,
@@ -3474,7 +3820,8 @@
           65,
           90
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG GINGER ROOT 7.99 F"
       },
       {
         "item_index": 11,
@@ -3489,7 +3836,8 @@
           64,
           89
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG 2 LB CARROTS 2.79 F"
       },
       {
         "item_index": 12,
@@ -3504,11 +3852,19 @@
           63,
           88
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "JALAPENO PEPPERS 1.00 F"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3565,7 +3921,8 @@
           45,
           57
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "BRIOCHE BURGER BUNS 6.99"
       },
       {
         "item_index": 1,
@@ -3579,7 +3936,8 @@
           43,
           56
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "RAW MILK 6.99"
       },
       {
         "item_index": 2,
@@ -3593,7 +3951,8 @@
           41,
           55
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SWEET CHILI SAUCE 3.99"
       },
       {
         "item_index": 3,
@@ -3607,7 +3966,8 @@
           39,
           54
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SEEDLESS LEMONS BAG 4.99"
       },
       {
         "item_index": 4,
@@ -3621,7 +3981,8 @@
           37,
           53
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "ORGANIC GREEN ONIONS 1.50"
       },
       {
         "item_index": 5,
@@ -3635,7 +3996,8 @@
           36,
           52
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "ORG GINGER ROOT 7.99"
       },
       {
         "item_index": 6,
@@ -3649,11 +4011,19 @@
           35,
           51
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "CRISPY ONIONS 2.49"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "match",
+    "reconciliation": {
+      "status": "match",
+      "item_sum": 34.94,
+      "baseline": 34.94,
+      "baseline_source": "grand_total_minus_tax",
+      "baseline_figures_agreeing": 1
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3716,7 +4086,8 @@
           21,
           37
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "LEMON EACH $0.98"
       },
       {
         "item_index": 1,
@@ -3730,7 +4101,8 @@
           19,
           36
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "A-AVOCADO HASS LARGE EAC $7.16"
       },
       {
         "item_index": 2,
@@ -3744,7 +4116,8 @@
           17,
           35
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "POTATO SWEET EACH $1.98"
       },
       {
         "item_index": 3,
@@ -3758,7 +4131,8 @@
           16,
           34
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "TUNA SOLID WHITE ALBACOR $1.99"
       },
       {
         "item_index": 4,
@@ -3772,7 +4146,8 @@
           14,
           33
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "TUNA SOLID WHITE ALBACOR $3.98"
       },
       {
         "item_index": 5,
@@ -3786,7 +4161,8 @@
           13,
           32
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SALSA AUTENTICA $2.29"
       },
       {
         "item_index": 6,
@@ -3800,7 +4176,8 @@
           12,
           31
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SALMON FILLET SKIN ON $6.69"
       },
       {
         "item_index": 7,
@@ -3814,7 +4191,8 @@
           11,
           30
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SALMON FILLET SKIN ON $9.39"
       },
       {
         "item_index": 8,
@@ -3829,7 +4207,8 @@
           10,
           29
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "MANGO NECTAR JUICE ORG 6 $5.49"
       },
       {
         "item_index": 9,
@@ -3843,11 +4222,19 @@
           8,
           28
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "ORG KOSHER DILL PICKLE S $3.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "match",
+    "reconciliation": {
+      "status": "match",
+      "item_sum": 43.94,
+      "baseline": 43.94,
+      "baseline_source": "grand_total_minus_tax",
+      "baseline_figures_agreeing": 1
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -3912,7 +4299,8 @@
           30,
           32
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Blueberries, 1 Pint now $2.39 F"
       },
       {
         "item_index": 1,
@@ -3928,7 +4316,8 @@
           29,
           31
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "365 Everyday Value, Orgar.. now $2.09 F"
       },
       {
         "item_index": 2,
@@ -3943,7 +4332,8 @@
           18,
           28
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Amazon Fresh Brand, Stopl. now $3.78"
       },
       {
         "item_index": 3,
@@ -3959,7 +4349,8 @@
           15,
           27
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Amazon Fresh, Greek Nonfa.. not $1.89"
       },
       {
         "item_index": 4,
@@ -3975,11 +4366,19 @@
           10,
           26
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Amazon Fresh, Small Curd nOW 950.93 F"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4035,7 +4434,8 @@
           55,
           73
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ROLLED OATS 7.00 F"
       },
       {
         "item_index": 1,
@@ -4049,7 +4449,8 @@
           43,
           54
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "SPROUTS LRG EGGS 3.99"
       },
       {
         "item_index": 2,
@@ -4063,7 +4464,8 @@
           42,
           53
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG A2/A2 6% FAT MLK 7.99"
       },
       {
         "item_index": 3,
@@ -4077,7 +4479,8 @@
           41,
           52
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "HEAVY WHIPPING CREAM 4.29"
       },
       {
         "item_index": 4,
@@ -4092,7 +4495,8 @@
           51,
           72
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "PENNE RIGATE PASTA 3.99 F"
       },
       {
         "item_index": 5,
@@ -4106,7 +4510,8 @@
           37,
           49
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "BOGO 50% OFF GROC -2.00"
       },
       {
         "item_index": 6,
@@ -4121,7 +4526,8 @@
           48,
           70
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "PENNE RIGATE PAST 3.99 F"
       },
       {
         "item_index": 7,
@@ -4136,11 +4542,19 @@
           47,
           69
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORGANIC SHALLOTS 3.49 F"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4207,7 +4621,8 @@
           71,
           72
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "SHALLOTS 0.84 F"
       },
       {
         "item_index": 1,
@@ -4221,7 +4636,8 @@
           60,
           69
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "GARLIC-BULK 2.24 F"
       },
       {
         "item_index": 2,
@@ -4236,7 +4652,8 @@
           67,
           68
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ITAL PARSLEY ORG 2.00 F"
       },
       {
         "item_index": 3,
@@ -4250,7 +4667,8 @@
           54,
           66
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "POTATO-RUSSET 9.74 F"
       },
       {
         "item_index": 4,
@@ -4264,7 +4682,8 @@
           48,
           51
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "BAG SALE PAPER EA 0.10"
       },
       {
         "item_index": 5,
@@ -4279,7 +4698,8 @@
           49,
           50
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "GELSON'S EGGS 4.99 F"
       },
       {
         "item_index": 6,
@@ -4293,7 +4713,8 @@
           39,
           42
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "CRUSHED TOMATOES 5.99 F"
       },
       {
         "item_index": 7,
@@ -4308,11 +4729,19 @@
           40,
           41
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "PENNE RIGATE #41 3.50 F"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4340,11 +4769,19 @@
           14,
           15
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "RAW WHOLE MILK 17.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4374,11 +4811,19 @@
           35,
           36
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "ORG FF GRASSFED MILK 8.49"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4414,11 +4859,19 @@
           12,
           13
         ],
-        "reconciliation_status": "no-baseline"
+        "reconciliation_status": "no-baseline",
+        "raw_text": "Large Popcorn 1 12.99"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "no-baseline",
+    "reconciliation": {
+      "status": "no-baseline",
+      "item_sum": null,
+      "baseline": null,
+      "baseline_source": null,
+      "baseline_figures_agreeing": null
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4462,7 +4915,8 @@
           13,
           24
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "LEMON EACH $2.94"
       },
       {
         "item_index": 1,
@@ -4476,7 +4930,8 @@
           12,
           23
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "VILLA ITALIA ITAL BLOOD $3.79"
       },
       {
         "item_index": 2,
@@ -4490,7 +4945,8 @@
           11,
           22
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SALMON FILLET SKIN OFF C $10.85"
       },
       {
         "item_index": 3,
@@ -4504,7 +4960,8 @@
           10,
           21
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "SALMON FILLET SKIN OFF $9.74"
       },
       {
         "item_index": 4,
@@ -4518,11 +4975,19 @@
           9,
           20
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "PORK AL PASTOR DICED $10.19"
       }
     ],
     "printed_subtotal": null,
     "reconciliation_status": "match",
+    "reconciliation": {
+      "status": "match",
+      "item_sum": 37.51,
+      "baseline": 37.51,
+      "baseline_source": "grand_total_minus_tax",
+      "baseline_figures_agreeing": 1
+    },
     "should_reocr_items_zone": false
   },
   {
@@ -4629,7 +5094,8 @@
           11,
           13
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "Pea Protein $0.00"
       },
       {
         "item_index": 1,
@@ -4643,11 +5109,19 @@
           10,
           12
         ],
-        "reconciliation_status": "match"
+        "reconciliation_status": "match",
+        "raw_text": "1 Peanut Paradise $8.99"
       }
     ],
     "printed_subtotal": 8.99,
     "reconciliation_status": "match",
+    "reconciliation": {
+      "status": "match",
+      "item_sum": 8.99,
+      "baseline": 8.99,
+      "baseline_source": "subtotal",
+      "baseline_figures_agreeing": 1
+    },
     "should_reocr_items_zone": false
   }
 ]

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
@@ -939,7 +939,7 @@
           "line_ids": [
             3
           ],
-          "reconciliation_status": "no-baseline",
+          "reconciliation_status": "match",
           "model_source": "swift-worker-v1",
           "extractor_version": "swift-worker-v1+line-items-blocks-v2",
           "raw_text": "ORGANIC 3.99"
@@ -949,11 +949,11 @@
       "printed_subtotal": null,
       "should_reocr_items_zone": false,
       "reconciliation": {
-        "status": "no-baseline",
-        "item_sum": null,
-        "baseline": null,
-        "baseline_source": null,
-        "baseline_figures_agreeing": null
+        "status": "match",
+        "item_sum": 3.99,
+        "baseline": 3.99,
+        "baseline_source": "grand_total_minus_tax",
+        "baseline_figures_agreeing": 1
       }
     }
   ],

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
@@ -946,7 +946,6 @@
         }
       ],
       "needs_review": false,
-      "printed_subtotal": null,
       "should_reocr_items_zone": false,
       "reconciliation": {
         "status": "match",

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_single_pass_contract.json
@@ -941,10 +941,20 @@
           ],
           "reconciliation_status": "no-baseline",
           "model_source": "swift-worker-v1",
-          "extractor_version": "swift-worker-v1+line-items-blocks-v2"
+          "extractor_version": "swift-worker-v1+line-items-blocks-v2",
+          "raw_text": "ORGANIC 3.99"
         }
       ],
-      "needs_review": false
+      "needs_review": false,
+      "printed_subtotal": null,
+      "should_reocr_items_zone": false,
+      "reconciliation": {
+        "status": "no-baseline",
+        "item_sum": null,
+        "baseline": null,
+        "baseline_source": null,
+        "baseline_figures_agreeing": null
+      }
     }
   ],
   "barcodes": []

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptStructurePipelineTests.swift
@@ -29,6 +29,7 @@ import Testing
         let lineItems: [ExpectedItem]
         let printedSubtotal: Double?
         let reconciliationStatus: String
+        let reconciliation: ExpectedReconciliation
         let shouldReocrItemsZone: Bool
 
         enum CodingKeys: String, CodingKey {
@@ -38,7 +39,24 @@ import Testing
             case lineItems = "line_items"
             case printedSubtotal = "printed_subtotal"
             case reconciliationStatus = "reconciliation_status"
+            case reconciliation
             case shouldReocrItemsZone = "should_reocr_items_zone"
+        }
+    }
+
+    struct ExpectedReconciliation: Decodable {
+        let status: String
+        let itemSum: Double?
+        let baseline: Double?
+        let baselineSource: String?
+        let baselineFiguresAgreeing: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case status
+            case itemSum = "item_sum"
+            case baseline
+            case baselineSource = "baseline_source"
+            case baselineFiguresAgreeing = "baseline_figures_agreeing"
         }
     }
 
@@ -62,6 +80,7 @@ import Testing
         let nameQuality: String
         let lineIds: [Int]
         let reconciliationStatus: String
+        let rawText: String
 
         enum CodingKeys: String, CodingKey {
             case itemIndex = "item_index"
@@ -73,6 +92,7 @@ import Testing
             case nameQuality = "name_quality"
             case lineIds = "line_ids"
             case reconciliationStatus = "reconciliation_status"
+            case rawText = "raw_text"
         }
     }
 
@@ -207,6 +227,7 @@ import Testing
                         || got.lineIds != wanted.lineIds
                         || got.reconciliationStatus
                             != wanted.reconciliationStatus
+                        || got.rawText != wanted.rawText
                         || got.modelSource != swiftWorkerModelSource
                         || got.extractorVersion
                             != swiftWorkerExtractorVersion
@@ -224,6 +245,17 @@ import Testing
                 != expectation.reconciliationStatus
             {
                 differences.append("reconciliation")
+            }
+            let gotRec = result.reconciliation
+            let wantRec = expectation.reconciliation
+            if gotRec.status != wantRec.status
+                || !equalMoney(gotRec.itemSum, wantRec.itemSum)
+                || !equalMoney(gotRec.baseline, wantRec.baseline)
+                || gotRec.baselineSource != wantRec.baselineSource
+                || gotRec.baselineFiguresAgreeing
+                    != wantRec.baselineFiguresAgreeing
+            {
+                differences.append("reconciliation detail")
             }
             if result.shouldReocrItemsZone
                 != expectation.shouldReocrItemsZone


### PR DESCRIPTION
## What

Tier 1 of moving line-item authority onto the Swift Mac worker ([inventory](https://github.com/tnorlund/Portfolio/pull/1391) discussion): the worker computed several verdicts on device and threw them away at the JSON boundary. This ships them, with no new decoder logic.

**Previously computed-and-discarded, now on the wire:**
- `printed_subtotal` — the worker's own printed-figure scan
- `should_reocr_items_zone` — the worker's re-OCR verdict (`ReceiptOutput` never carried it; the device's opinion never reached AWS)
- `reconciliation` — the graded #1324 verdict (`reconcileLineItems` already delegated to the detailed implementation; `baseline_source` / `baseline_figures_agreeing` were computed and dropped)
- `raw_text` per line item — every worker row previously landed with `raw_text == ""`

**Two behavioral alignments with the cloud recompute, both parity-mirrored:**
- The on-device decode now passes the scanned summary, so the summary-figure filter (#1320) runs on device exactly as in the cloud path.
- `proposeItemsBoundaryExtension` (#1329) — ported, parity-tested, and never called — is now wired into `buildOnDeviceReceiptStructure`. Accepted only on strict arithmetic improvement; the widened ITEMS section ships in the payload.

**Ingest:** `_persist_worker_structure` passes `raw_text` through and stamps the receipt-level `baseline_figures_agreeing` on every worker row, so worker rows carry the same diagnostics as cloud-recomputed ones.

## Parity

`generate_receipt_structure_parity.py` mirrors the pipeline changes and the fixture is regenerated from live Python. **Zero behavioral drift across all 38 golden receipts** — the extension never fires on already-reconciling zones and the scanned-summary filter had nothing new to drop; every fixture diff is an additive field. The structure test now also pins the graded reconciliation and `raw_text`.

## Verification

- `swift build` + all 41 swift-testing suites pass locally (3 parity gates included)
- `generate_line_items_parity.py --check`: fresh — decoder untouched
- 17 payload-contract tests pass, including new grade-stamping coverage
- All new wire fields are optional: payloads from earlier worker builds decode and persist unchanged

Tier 2 (Dynamo write surface for the worker) and Tier 3 (second worker pass on summary arrival) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receipt results now include printed subtotals, detailed reconciliation details, baseline information, and item-zone reprocessing recommendations.
  * Line items retain their original scanned text for improved traceability.
  * Receipt structure output includes proposed section improvements and expanded review metadata.
* **Improvements**
  * Reconciliation results are consistently applied across line items.
  * Receipt processing remains reliable when reconciliation data is malformed or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->