### PR TITLE
feat(swift-worker): direct DynamoDB write surface for decoded structure (Tier 2)

### DIFF
--- a/docs/architecture/mac-ocr-aws-handoff.md
+++ b/docs/architecture/mac-ocr-aws-handoff.md
@@ -212,14 +212,26 @@ Returned to AWS by the Swift worker:
   exist would fire the stream's canonical-ITEMS trigger and cause a
   premature cloud recompute against a word-less receipt. The
   `addReceiptSections` surface exists for the summary-refine pass.
-  **Redelivery guard:** the write is skipped entirely (logged
-  `worker_line_items_skip_redelivery`) when the job row was already
-  COMPLETED at fetch time — a redelivered message whose first attempt
-  already reached the cloud pipeline, so the rows may carry enrichment
-  (merchant rollup keys, VALID section provenance, reconciliation against
-  the real summary) that the worker's sparse payload would erase. A first
-  attempt that crashed leaves the job PENDING and emitted no results
-  message, so no enrichment exists and the write still runs;
+  **Redelivery guard:** the single-pass write is *conditional per row*
+  (`addReceiptLineItemsIfWorkerOwned`) — one `PutItem` each, with
+  `attribute_not_exists(PK) OR begins_with(extractor_version,
+  "swift-worker")`, because DynamoDB batch writes cannot carry a
+  condition. Cloud-written rows stamp the bare decoder version
+  (`line-items-blocks-v2`) with no `swift-worker` prefix, so the condition
+  fails on exactly the rows the cloud owns and may have enriched since
+  (merchant name plus the GSI1 rollup keys it unlocks, VALID section
+  provenance, reconciliation against the real summary); a
+  `ConditionalCheckFailedException` is not an error — the row is left
+  alone and counted into `skipped_cloud_owned` on the
+  `worker_line_items_written` log line. This holds for every interleaving,
+  including the one the job-status check misses: a first attempt that
+  crashed *after* sending its `ocr-results` message but *before* marking
+  the job COMPLETED comes back as PENDING. The COMPLETED-at-fetch-time
+  skip (logged `worker_line_items_skip_redelivery`) is kept purely as a
+  fast path — every put in that delivery would be rejected anyway, so the
+  round trips are wasted. The summary-refine pass deliberately keeps using
+  the unconditional `addReceiptLineItems`: it runs after the cloud
+  pipeline and is meant to overwrite;
 - `OCRRoutingDecision` (PENDING) pointing at the JSON;
 - an `ocr-results` SQS message:
   `{image_id, job_id, s3_key, s3_bucket, receipt_count}`.

--- a/docs/architecture/mac-ocr-aws-handoff.md
+++ b/docs/architecture/mac-ocr-aws-handoff.md
@@ -198,6 +198,20 @@ Returned to AWS by the Swift worker:
   receipt's model labels (the words pipeline then runs with whatever
   labels exist, possibly none). A durable retry/reconciliation path is
   listed under follow-ups;
+- `ReceiptLineItem` items written directly to DynamoDB (Tier 2 of the
+  worker-authority migration): the worker re-reads its own decoded
+  `line_items` from the result JSON and batch-puts them via
+  `ReceiptStructureItems.lineItemItem`, whose serialization is pinned
+  byte-for-byte against `ReceiptLineItem.to_item()` by the shared
+  fixture `swift_dynamo_items_contract.json` (Swift + Python contract
+  tests). **Best-effort like labels** — a failure is logged
+  (`failed_write_line_items`) and ingest still persists the same rows
+  from the JSON payload (delete-then-add), which remains the staleness
+  reconciler of record. Sections are deliberately NOT written by the
+  worker at single-pass time: a section write before the receipt's words
+  exist would fire the stream's canonical-ITEMS trigger and cause a
+  premature cloud recompute against a word-less receipt. The
+  `addReceiptSections` surface exists for the summary-refine pass;
 - `OCRRoutingDecision` (PENDING) pointing at the JSON;
 - an `ocr-results` SQS message:
   `{image_id, job_id, s3_key, s3_bucket, receipt_count}`.

--- a/docs/architecture/mac-ocr-aws-handoff.md
+++ b/docs/architecture/mac-ocr-aws-handoff.md
@@ -211,7 +211,15 @@ Returned to AWS by the Swift worker:
   worker at single-pass time: a section write before the receipt's words
   exist would fire the stream's canonical-ITEMS trigger and cause a
   premature cloud recompute against a word-less receipt. The
-  `addReceiptSections` surface exists for the summary-refine pass;
+  `addReceiptSections` surface exists for the summary-refine pass.
+  **Redelivery guard:** the write is skipped entirely (logged
+  `worker_line_items_skip_redelivery`) when the job row was already
+  COMPLETED at fetch time — a redelivered message whose first attempt
+  already reached the cloud pipeline, so the rows may carry enrichment
+  (merchant rollup keys, VALID section provenance, reconciliation against
+  the real summary) that the worker's sparse payload would erase. A first
+  attempt that crashed leaves the job PENDING and emitted no results
+  message, so no enrichment exists and the write still runs;
 - `OCRRoutingDecision` (PENDING) pointing at the JSON;
 - an `ocr-results` SQS message:
   `{image_id, job_id, s3_key, s3_bucket, receipt_count}`.

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_dynamo_items_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_dynamo_items_contract.py
@@ -1,0 +1,113 @@
+"""Contract tests for the Swift worker's DIRECT DynamoDB item writes.
+
+Tier 2 of the worker-authority migration gave the Mac worker a Dynamo
+write surface (`ReceiptStructureItems` in receipt_ocr_swift). Its item
+serialization must stay byte-compatible with the receipt_dynamo entity
+writers, so both sides pin the shared fixture
+``receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/``
+``swift_dynamo_items_contract.json``:
+
+* the Swift side (``DynamoItemContractTests``) asserts the serializer
+  reproduces the fixture byte-for-byte;
+* this side asserts ``item_to_receipt_section`` /
+  ``item_to_receipt_line_item`` parse the fixture back into valid
+  entities with the exact field values.
+
+A schema drift on either side fails a local suite before it fails
+against the real table.
+"""
+
+import json
+from pathlib import Path
+
+from receipt_dynamo.entities.receipt_line_item import (
+    item_to_receipt_line_item,
+)
+from receipt_dynamo.entities.receipt_section import item_to_receipt_section
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_FIXTURE_PATH = (
+    _REPO_ROOT
+    / "receipt_ocr_swift"
+    / "Tests"
+    / "ReceiptOCRCoreTests"
+    / "Fixtures"
+    / "swift_dynamo_items_contract.json"
+)
+
+IMAGE_ID = "12345678-1234-4123-8123-123456789012"
+
+
+def _fixture() -> dict:
+    with open(_FIXTURE_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_swift_section_item_parses_into_a_valid_entity():
+    section = item_to_receipt_section(_fixture()["section"])
+    assert section.image_id == IMAGE_ID
+    assert section.receipt_id == 1
+    assert section.section_type == "ITEMS"
+    assert section.line_ids == [3, 4]
+    assert section.row_ids == [3]
+    assert section.confidence == 0.95
+    assert section.model_source == "swift-worker-v1"
+    assert section.validation_status == "PENDING"
+
+
+def test_swift_line_item_parses_into_a_valid_entity():
+    item = item_to_receipt_line_item(_fixture()["line_item"])
+    assert item.image_id == IMAGE_ID
+    assert item.receipt_id == 1
+    assert item.item_index == 0
+    assert item.name == "ORGANIC"
+    assert item.price == "3.99"
+    assert item.line_ids == [3]
+    assert item.extractor_version == "swift-worker-v1+line-items-blocks-v2"
+    assert item.quantity == 2.0
+    assert item.unit_price == 1.99
+    assert item.is_discount is False
+    assert item.collapsed_banding is False
+    assert item.name_quality == "ok"
+    assert item.raw_text == "ORGANIC 3.99"
+    assert item.source_section_status == "PENDING"
+    assert item.source_model_source == "swift-worker-v1"
+    assert item.reconciliation_status == "match"
+    assert item.baseline_figures_agreeing == 2
+    # Worker rows never carry a merchant, so the sparse GSI must be
+    # absent from the round-tripped item too.
+    assert item.merchant_name is None
+    assert "GSI1PK" not in item.to_item()
+
+
+def test_swift_line_item_round_trips_through_the_python_writer():
+    """The Swift item and the Python writer's item agree key-for-key.
+
+    Parsing the fixture into an entity and re-serializing it through
+    ``ReceiptLineItem.to_item()`` must reproduce the fixture exactly —
+    proving the Swift serializer matches the Python writer, not merely
+    that Python tolerates it.
+
+    Timestamps are compared semantically rather than byte-for-byte:
+    Swift always writes millisecond precision (".000") while Python's
+    ``isoformat()`` omits zero microseconds. ``fromisoformat`` parses
+    both, so the difference is representational only.
+    """
+    _TIMESTAMP_KEYS = {"created_at", "extracted_at"}
+
+    def _without_timestamps(item: dict) -> dict:
+        return {k: v for k, v in item.items() if k not in _TIMESTAMP_KEYS}
+
+    fixture_item = _fixture()["line_item"]
+    entity = item_to_receipt_line_item(fixture_item)
+    assert _without_timestamps(entity.to_item()) == _without_timestamps(
+        fixture_item
+    )
+    assert entity._extracted_at_iso().startswith("2026-08-11T00:00:00")
+
+    fixture_section = _fixture()["section"]
+    section = item_to_receipt_section(fixture_section)
+    assert _without_timestamps(section.to_item()) == _without_timestamps(
+        fixture_section
+    )
+    assert section.created_at.isoformat().startswith("2026-08-11T00:00:00")

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/AWSProtocols.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/AWSProtocols.swift
@@ -53,15 +53,45 @@ public protocol DynamoClientProtocol {
         sections: [ReceiptSectionPayload], createdAt: Date
     ) async throws
 
-    /// Batch-put worker-decoded line items (upsert semantics). Line-item
-    /// writes fire no stream trigger, so the single-pass worker calls
-    /// this directly; the cloud ingest's delete-then-add over the same
-    /// payload remains the staleness reconciler of record.
+    /// Batch-put worker-decoded line items (upsert semantics, unconditional).
+    /// Line-item writes fire no stream trigger, so the worker can call this
+    /// directly; the cloud ingest's delete-then-add over the same payload
+    /// remains the staleness reconciler of record. The summary-refine pass
+    /// is the caller — it runs after the cloud pipeline and is meant to
+    /// overwrite whatever is there. The single-pass write must NOT use this;
+    /// see `addReceiptLineItemsIfWorkerOwned`.
     func addReceiptLineItems(
         imageId: String, receiptId: Int,
         items: [ReceiptLineItemPayload], extractedAt: Date,
         baselineFiguresAgreeing: Int?
     ) async throws
+
+    /// Per-item conditional put of worker-decoded line items: a row is
+    /// written only when it does not exist yet or the worker itself wrote
+    /// it (`extractor_version` begins with
+    /// `swiftWorkerExtractorVersionPrefix`).
+    ///
+    /// Ownership rule: rows the cloud pipeline produced carry the bare
+    /// decoder version (`line-items-blocks-v2`) with no `swift-worker`
+    /// prefix, and may have been enriched since (merchant_name plus the
+    /// GSI1 rollup keys it unlocks, VALID section provenance,
+    /// reconciliation against the real summary). The worker's single-pass
+    /// payload is sparse by design, so replacing such a row can only
+    /// destroy information — the condition makes that impossible for every
+    /// ordering of crash, redelivery and cloud enrichment, not just the
+    /// ones the job-status check happens to catch.
+    ///
+    /// Conditional writes cannot ride a DynamoDB batch, so this issues one
+    /// `PutItem` per row. A `ConditionalCheckFailedException` is not an
+    /// error: it means the row is cloud-owned and is skipped.
+    ///
+    /// - Returns: how many rows were skipped as cloud-owned.
+    @discardableResult
+    func addReceiptLineItemsIfWorkerOwned(
+        imageId: String, receiptId: Int,
+        items: [ReceiptLineItemPayload], extractedAt: Date,
+        baselineFiguresAgreeing: Int?
+    ) async throws -> Int
 }
 
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/AWSProtocols.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/AWSProtocols.swift
@@ -41,6 +41,27 @@ public protocol DynamoClientProtocol {
     func updateOCRJobStage(imageId: String, jobId: String, stage: String) async throws
     func addOCRRoutingDecision(_ decision: OCRRoutingDecision) async throws
     func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws
+
+    /// Batch-put worker-decoded sections (upsert semantics, matching the
+    /// cloud ingest's batch put "so an SQS redelivery rewrites rather
+    /// than raising"). NOT called at single-pass time — a section write
+    /// before the receipt's words exist would fire the stream's canonical
+    /// ITEMS trigger and cause a premature cloud recompute against a
+    /// word-less receipt. The summary-refine pass is the caller.
+    func addReceiptSections(
+        imageId: String, receiptId: Int,
+        sections: [ReceiptSectionPayload], createdAt: Date
+    ) async throws
+
+    /// Batch-put worker-decoded line items (upsert semantics). Line-item
+    /// writes fire no stream trigger, so the single-pass worker calls
+    /// this directly; the cloud ingest's delete-then-add over the same
+    /// payload remains the staleness reconciler of record.
+    func addReceiptLineItems(
+        imageId: String, receiptId: Int,
+        items: [ReceiptLineItemPayload], extractedAt: Date,
+        baselineFiguresAgreeing: Int?
+    ) async throws
 }
 
 

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/ReceiptStructureItems.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/ReceiptStructureItems.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SotoDynamoDB
+
+/// DynamoDB item serialization for worker-produced receipt structure.
+///
+/// Mirrors the Python entity writers exactly — `ReceiptSection.to_item()`
+/// and `ReceiptLineItem.to_item()` in `receipt_dynamo` — so rows written by
+/// the Mac worker are byte-compatible with rows written by the cloud. The
+/// contract is pinned on both sides of the boundary by
+/// `Tests/ReceiptOCRCoreTests/Fixtures/swift_dynamo_items_contract.json`:
+/// a Swift test asserts this serializer reproduces the fixture, and
+/// `infra/upload_images/container_ocr/handler/tests/`
+/// `test_swift_dynamo_items_contract.py` asserts `item_to_receipt_section`
+/// / `item_to_receipt_line_item` parse it back into valid entities.
+public enum ReceiptStructureItems {
+    /// Mirror of `ReceiptSection.to_item()` for a worker-produced section:
+    /// PENDING validation status, worker provenance, no GSI keys (the
+    /// section schema has none).
+    public static func sectionItem(
+        imageId: String,
+        receiptId: Int,
+        section: ReceiptSectionPayload,
+        createdAt: Date
+    ) -> [String: DynamoDB.AttributeValue] {
+        [
+            "PK": .s("IMAGE#\(imageId)"),
+            "SK": .s(
+                String(
+                    format: "RECEIPT#%05d#SECTION#%@",
+                    receiptId, section.sectionType
+                )
+            ),
+            "TYPE": .s("RECEIPT_SECTION"),
+            "section_type": .s(section.sectionType),
+            "line_ids": .l(section.lineIds.map { .n(String($0)) }),
+            "created_at": .s(ISO8601Python.format(createdAt)),
+            "confidence": .n(String(section.confidence)),
+            "model_source": .s(section.modelSource),
+            "validation_status": .s("PENDING"),
+            "row_ids": .l(section.rowIds.map { .n(String($0)) }),
+        ]
+    }
+
+    /// Mirror of `ReceiptLineItem.to_item()` for a worker-produced row.
+    ///
+    /// The merchant GSI (GSI1) is always omitted: merchant resolution is
+    /// cloud-side, so worker rows never carry a `merchant_name`, and the
+    /// sparse-GSI rule skips exactly that case. `collapsed_banding` is
+    /// always false — the Python band-block decoder pins it false too.
+    public static func lineItemItem(
+        imageId: String,
+        receiptId: Int,
+        item payload: ReceiptLineItemPayload,
+        extractedAt: Date,
+        baselineFiguresAgreeing: Int?
+    ) -> [String: DynamoDB.AttributeValue] {
+        var item: [String: DynamoDB.AttributeValue] = [
+            "PK": .s("IMAGE#\(imageId)"),
+            "SK": .s(
+                String(
+                    format: "RECEIPT#%05d#LINE_ITEM#%05d",
+                    receiptId, payload.itemIndex
+                )
+            ),
+            "TYPE": .s("RECEIPT_LINE_ITEM"),
+            "name": .s(payload.name),
+            "price": .s(String(format: "%.2f", payload.price)),
+            "line_ids": .l(payload.lineIds.map { .n(String($0)) }),
+            "extractor_version": .s(payload.extractorVersion),
+            "extracted_at": .s(ISO8601Python.format(extractedAt)),
+            "is_discount": .bool(payload.isDiscount),
+            "collapsed_banding": .bool(false),
+            "name_quality": .s(payload.nameQuality),
+            "raw_text": .s(payload.rawText ?? ""),
+            "source_section_status": .s("PENDING"),
+            "source_model_source": .s(payload.modelSource),
+            "reconciliation_status": .s(payload.reconciliationStatus),
+        ]
+        if let quantity = payload.quantity {
+            item["quantity"] = .n(String(quantity))
+        }
+        if let unitPrice = payload.unitPrice {
+            item["unit_price"] = .n(String(unitPrice))
+        }
+        if let grade = baselineFiguresAgreeing {
+            item["baseline_figures_agreeing"] = .n(String(grade))
+        }
+        return item
+    }
+}

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
@@ -180,20 +180,60 @@ public final class SotoDynamoClient: DynamoClientProtocol {
     }
 
     public func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws {
-        guard !labels.isEmpty else { return }
+        try await batchPutItems(
+            labels.map {
+                Self.convertToAttributeValues($0.toDynamoItemDict())
+            }
+        )
+    }
+
+    public func addReceiptSections(
+        imageId: String, receiptId: Int,
+        sections: [ReceiptSectionPayload], createdAt: Date
+    ) async throws {
+        try await batchPutItems(
+            sections.map {
+                ReceiptStructureItems.sectionItem(
+                    imageId: imageId, receiptId: receiptId,
+                    section: $0, createdAt: createdAt
+                )
+            }
+        )
+    }
+
+    public func addReceiptLineItems(
+        imageId: String, receiptId: Int,
+        items: [ReceiptLineItemPayload], extractedAt: Date,
+        baselineFiguresAgreeing: Int?
+    ) async throws {
+        try await batchPutItems(
+            items.map {
+                ReceiptStructureItems.lineItemItem(
+                    imageId: imageId, receiptId: receiptId,
+                    item: $0, extractedAt: extractedAt,
+                    baselineFiguresAgreeing: baselineFiguresAgreeing
+                )
+            }
+        )
+    }
+
+    /// Batch-put with chunking, unprocessed-item retry and backoff —
+    /// shared by labels, sections and line items.
+    private func batchPutItems(
+        _ items: [[String: DynamoDB.AttributeValue]]
+    ) async throws {
+        guard !items.isEmpty else { return }
 
         // Process in chunks of 25 (DynamoDB batch write limit)
         let chunkSize = 25
-        var remaining = labels[...]
+        var remaining = items[...]
 
         while !remaining.isEmpty {
             let chunk = remaining.prefix(chunkSize)
             remaining = remaining.dropFirst(chunkSize)
 
-            var writeRequests = chunk.map { label -> DynamoDB.WriteRequest in
-                let dict = label.toDynamoItemDict()
-                let item = Self.convertToAttributeValues(dict)
-                return DynamoDB.WriteRequest(putRequest: .init(item: item))
+            var writeRequests = chunk.map { item -> DynamoDB.WriteRequest in
+                DynamoDB.WriteRequest(putRequest: .init(item: item))
             }
 
             // Retry with exponential backoff until all items are processed

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/AWS/SotoAWSClients.swift
@@ -217,6 +217,45 @@ public final class SotoDynamoClient: DynamoClientProtocol {
         )
     }
 
+    @discardableResult
+    public func addReceiptLineItemsIfWorkerOwned(
+        imageId: String, receiptId: Int,
+        items: [ReceiptLineItemPayload], extractedAt: Date,
+        baselineFiguresAgreeing: Int?
+    ) async throws -> Int {
+        // One PutItem per row: DynamoDB batch writes cannot carry a
+        // condition expression, and the condition is the whole point here.
+        // The row is ours to write only if nothing is there yet or the
+        // worker stamped what is (see the protocol's ownership rule).
+        var skipped = 0
+        for payload in items {
+            let item = ReceiptStructureItems.lineItemItem(
+                imageId: imageId, receiptId: receiptId,
+                item: payload, extractedAt: extractedAt,
+                baselineFiguresAgreeing: baselineFiguresAgreeing
+            )
+            let req = DynamoDB.PutItemInput(
+                conditionExpression:
+                    "attribute_not_exists(PK) OR begins_with(extractor_version, :worker)",
+                expressionAttributeValues: [
+                    ":worker": .s(swiftWorkerExtractorVersionPrefix)
+                ],
+                item: item,
+                tableName: tableName
+            )
+            do {
+                _ = try await dynamo.putItem(req)
+            } catch let error as AWSErrorType
+                where error.errorCode
+                    == DynamoDBErrorType.conditionalCheckFailedException.errorCode
+            {
+                // Cloud-owned row: leave it exactly as the pipeline left it.
+                skipped += 1
+            }
+        }
+        return skipped
+    }
+
     /// Batch-put with chunking, unprocessed-item retry and backoff —
     /// shared by labels, sections and line items.
     private func batchPutItems(

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/ReceiptProcessing/ReceiptStructurePipeline.swift
@@ -18,6 +18,12 @@ public let swiftWorkerDecoderVersion = "line-items-blocks-v2"
 public let swiftWorkerExtractorVersion =
     "\(swiftWorkerModelSource)+\(swiftWorkerDecoderVersion)"
 
+/// The prefix every worker-written `extractor_version` shares, whatever the
+/// build or decoder version. Cloud-written rows carry the bare decoder
+/// version (`line-items-blocks-v2`), so a `begins_with` test on this prefix
+/// distinguishes "the worker owns this row" from "the cloud owns this row".
+public let swiftWorkerExtractorVersionPrefix = "swift-worker"
+
 /// JSON contract for one on-device section prediction.
 public struct ReceiptSectionPayload: Codable, Sendable, Equatable {
     public let sectionType: String

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
@@ -292,6 +292,10 @@ public final class OCRWorker {
             /// region (REGIONAL_REOCR only; nil otherwise). Recorded in
             /// the uploaded result JSON as `reocr_strategy_applied`.
             let strategyApplied: String?
+            /// Whether the job row was already COMPLETED when it was fetched,
+            /// i.e. this delivery is a redelivery of work that already
+            /// finished. Gates the direct line-item write (see below).
+            let jobWasCompleted: Bool
         }
         var imageURLs: [URL] = []
         var contexts: [Context] = []
@@ -386,7 +390,8 @@ public final class OCRWorker {
                         jobId: jobId,
                         s3Bucket: config.rawBucketName,
                         jobType: job.jobType,
-                        strategyApplied: strategy.rawValue
+                        strategyApplied: strategy.rawValue,
+                        jobWasCompleted: job.status == .completed
                     )
                 )
                 logger.info(
@@ -407,7 +412,8 @@ public final class OCRWorker {
                     jobId: jobId,
                     s3Bucket: config.rawBucketName,
                     jobType: job.jobType,
-                    strategyApplied: nil
+                    strategyApplied: nil,
+                    jobWasCompleted: job.status == .completed
                 )
             )
         }
@@ -553,27 +559,43 @@ public final class OCRWorker {
             // write before the receipt's words exist would fire the
             // stream's canonical-ITEMS trigger and cause a premature
             // cloud recompute against a word-less receipt.
+            //
+            // Skipped when the job was already COMPLETED at fetch time: that
+            // means an earlier attempt already handed results to the cloud
+            // pipeline, which may since have enriched these rows (merchant
+            // rollup keys, VALID section provenance, reconciliation against
+            // the real summary). The worker's payload is sparse by design, so
+            // re-putting it over enriched rows can only destroy information.
+            // A first attempt that crashed leaves the job PENDING and never
+            // emitted a results message, so no enrichment exists and the
+            // write is safe.
             if ctx.jobType != .regionalReocr {
-                for receipt in receipts where !receipt.lineItems.isEmpty {
-                    let receiptId = receipt.clusterId
-                    do {
-                        try await Retry.withBackoff {
-                            try await self.dynamo.addReceiptLineItems(
-                                imageId: ctx.imageId,
-                                receiptId: receiptId,
-                                items: receipt.lineItems,
-                                extractedAt: now,
-                                baselineFiguresAgreeing: receipt
-                                    .reconciliation?.baselineFiguresAgreeing
+                if ctx.jobWasCompleted {
+                    logger.info(
+                        "worker_line_items_skip_redelivery image_id=\(ctx.imageId) job_id=\(ctx.jobId)"
+                    )
+                } else {
+                    for receipt in receipts where !receipt.lineItems.isEmpty {
+                        let receiptId = receipt.clusterId
+                        do {
+                            try await Retry.withBackoff {
+                                try await self.dynamo.addReceiptLineItems(
+                                    imageId: ctx.imageId,
+                                    receiptId: receiptId,
+                                    items: receipt.lineItems,
+                                    extractedAt: now,
+                                    baselineFiguresAgreeing: receipt
+                                        .reconciliation?.baselineFiguresAgreeing
+                                )
+                            }
+                            logger.info(
+                                "worker_line_items_written image_id=\(ctx.imageId) receipt_id=\(receiptId) count=\(receipt.lineItems.count)"
+                            )
+                        } catch {
+                            logger.warning(
+                                "failed_write_line_items image_id=\(ctx.imageId) receipt_id=\(receiptId) error=\(error)"
                             )
                         }
-                        logger.info(
-                            "worker_line_items_written image_id=\(ctx.imageId) receipt_id=\(receiptId) count=\(receipt.lineItems.count)"
-                        )
-                    } catch {
-                        logger.warning(
-                            "failed_write_line_items image_id=\(ctx.imageId) receipt_id=\(receiptId) error=\(error)"
-                        )
                     }
                 }
             }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
@@ -294,7 +294,9 @@ public final class OCRWorker {
             let strategyApplied: String?
             /// Whether the job row was already COMPLETED when it was fetched,
             /// i.e. this delivery is a redelivery of work that already
-            /// finished. Gates the direct line-item write (see below).
+            /// finished. A cheap fast path around the direct line-item write,
+            /// whose per-row condition is the actual safety guarantee (see
+            /// below).
             let jobWasCompleted: Bool
         }
         var imageURLs: [URL] = []
@@ -560,15 +562,19 @@ public final class OCRWorker {
             // stream's canonical-ITEMS trigger and cause a premature
             // cloud recompute against a word-less receipt.
             //
-            // Skipped when the job was already COMPLETED at fetch time: that
-            // means an earlier attempt already handed results to the cloud
-            // pipeline, which may since have enriched these rows (merchant
-            // rollup keys, VALID section provenance, reconciliation against
-            // the real summary). The worker's payload is sparse by design, so
-            // re-putting it over enriched rows can only destroy information.
-            // A first attempt that crashed leaves the job PENDING and never
-            // emitted a results message, so no enrichment exists and the
-            // write is safe.
+            // Every row is written CONDITIONALLY: a put lands only where no
+            // row exists yet or the worker itself wrote the one that does.
+            // Rows the cloud pipeline produced may since have been enriched
+            // (merchant rollup keys, VALID section provenance, reconciliation
+            // against the real summary), and the worker's sparse payload
+            // would erase that — the condition is what guarantees it cannot,
+            // under any interleaving of crash, redelivery and enrichment.
+            //
+            // The COMPLETED-at-fetch-time check below is only a fast path: a
+            // redelivery of finished work would have every put rejected
+            // anyway, so skip the round trips. It is NOT the guarantee —
+            // a first attempt that crashed after sending its results message
+            // but before marking the job COMPLETED comes back as PENDING.
             if ctx.jobType != .regionalReocr {
                 if ctx.jobWasCompleted {
                     logger.info(
@@ -578,18 +584,20 @@ public final class OCRWorker {
                     for receipt in receipts where !receipt.lineItems.isEmpty {
                         let receiptId = receipt.clusterId
                         do {
-                            try await Retry.withBackoff {
-                                try await self.dynamo.addReceiptLineItems(
-                                    imageId: ctx.imageId,
-                                    receiptId: receiptId,
-                                    items: receipt.lineItems,
-                                    extractedAt: now,
-                                    baselineFiguresAgreeing: receipt
-                                        .reconciliation?.baselineFiguresAgreeing
-                                )
+                            let skipped = try await Retry.withBackoff {
+                                try await self.dynamo
+                                    .addReceiptLineItemsIfWorkerOwned(
+                                        imageId: ctx.imageId,
+                                        receiptId: receiptId,
+                                        items: receipt.lineItems,
+                                        extractedAt: now,
+                                        baselineFiguresAgreeing: receipt
+                                            .reconciliation?
+                                            .baselineFiguresAgreeing
+                                    )
                             }
                             logger.info(
-                                "worker_line_items_written image_id=\(ctx.imageId) receipt_id=\(receiptId) count=\(receipt.lineItems.count)"
+                                "worker_line_items_written image_id=\(ctx.imageId) receipt_id=\(receiptId) count=\(receipt.lineItems.count - skipped) skipped_cloud_owned=\(skipped)"
                             )
                         } catch {
                             logger.warning(

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Worker/OCRWorker.swift
@@ -46,6 +46,11 @@ private struct ParsedReceiptInfo {
     let warpedHeight: Int
     let lineIndices: [Int]
     let layoutLMPredictions: [ParsedLinePrediction]?
+    /// On-device decoded line items, re-read from the result JSON so the
+    /// worker can write them to DynamoDB directly.
+    let lineItems: [ReceiptLineItemPayload]
+    /// Receipt-level graded reconciliation verdict, when present.
+    let reconciliation: ReceiptReconciliationPayload?
 }
 
 /// Parsed LayoutLM prediction for a line
@@ -116,6 +121,25 @@ private func parseReceiptsFromJSON(_ jsonData: Data) -> [ParsedReceiptInfo] {
             }
         }
 
+        // Re-decode the typed structure payloads through Codable so the
+        // Dynamo write path shares one source of truth with the wire
+        // contract (a hand-rolled dict parse here would be a third schema).
+        var lineItems: [ReceiptLineItemPayload] = []
+        if let itemsArray = receiptDict["line_items"] as? [[String: Any]],
+           let data = try? JSONSerialization.data(withJSONObject: itemsArray),
+           let decoded = try? JSONDecoder().decode(
+               [ReceiptLineItemPayload].self, from: data
+           ) {
+            lineItems = decoded
+        }
+        var reconciliation: ReceiptReconciliationPayload? = nil
+        if let recDict = receiptDict["reconciliation"] as? [String: Any],
+           let data = try? JSONSerialization.data(withJSONObject: recDict) {
+            reconciliation = try? JSONDecoder().decode(
+                ReceiptReconciliationPayload.self, from: data
+            )
+        }
+
         return ParsedReceiptInfo(
             clusterId: clusterId,
             localFileName: s3Key,  // s3Key initially contains local filename
@@ -123,7 +147,9 @@ private func parseReceiptsFromJSON(_ jsonData: Data) -> [ParsedReceiptInfo] {
             warpedWidth: warpedWidth,
             warpedHeight: warpedHeight,
             lineIndices: lineIndices,
-            layoutLMPredictions: layoutLMPredictions
+            layoutLMPredictions: layoutLMPredictions,
+            lineItems: lineItems,
+            reconciliation: reconciliation
         )
     }
 }
@@ -517,6 +543,40 @@ public final class OCRWorker {
                 }
             }
             #endif
+
+            // Write the on-device decoded line items straight to DynamoDB
+            // (Tier 2 of the worker-authority migration). Best-effort like
+            // the labels write: the ingest Lambda still persists the same
+            // rows from the JSON payload (delete-then-add), so a failure
+            // here costs nothing but the head start. Sections are NOT
+            // written from the worker at single-pass time — a section
+            // write before the receipt's words exist would fire the
+            // stream's canonical-ITEMS trigger and cause a premature
+            // cloud recompute against a word-less receipt.
+            if ctx.jobType != .regionalReocr {
+                for receipt in receipts where !receipt.lineItems.isEmpty {
+                    let receiptId = receipt.clusterId
+                    do {
+                        try await Retry.withBackoff {
+                            try await self.dynamo.addReceiptLineItems(
+                                imageId: ctx.imageId,
+                                receiptId: receiptId,
+                                items: receipt.lineItems,
+                                extractedAt: now,
+                                baselineFiguresAgreeing: receipt
+                                    .reconciliation?.baselineFiguresAgreeing
+                            )
+                        }
+                        logger.info(
+                            "worker_line_items_written image_id=\(ctx.imageId) receipt_id=\(receiptId) count=\(receipt.lineItems.count)"
+                        )
+                    } catch {
+                        logger.warning(
+                            "failed_write_line_items image_id=\(ctx.imageId) receipt_id=\(receiptId) error=\(error)"
+                        )
+                    }
+                }
+            }
 
             // Record the applied preprocess strategy in the uploaded result
             // JSON (REGIONAL_REOCR only) so the overlay Lambda can persist

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/DynamoItemContractTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/DynamoItemContractTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SotoDynamoDB
+import Testing
+
+@testable import ReceiptOCRCore
+
+/// Contract tests for the worker's direct DynamoDB item serialization.
+///
+/// The fixture `swift_dynamo_items_contract.json` is pinned on both sides
+/// of the boundary: this suite asserts `ReceiptStructureItems` reproduces
+/// it exactly, and `test_swift_dynamo_items_contract.py` (Python) asserts
+/// `item_to_receipt_section` / `item_to_receipt_line_item` parse it back
+/// into valid `receipt_dynamo` entities. A drift on either side fails a
+/// local test before it fails against the real table.
+struct DynamoItemContractTests {
+    static let imageId = "12345678-1234-4123-8123-123456789012"
+
+    static var fixtureTimestamp: Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 8
+        components.day = 11
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        return Calendar(identifier: .gregorian).date(from: components)!
+    }
+
+    private func loadFixture() throws -> [String: [String: DynamoDB.AttributeValue]] {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: "swift_dynamo_items_contract",
+                withExtension: "json", subdirectory: "Fixtures"
+            )
+        )
+        return try JSONDecoder().decode(
+            [String: [String: DynamoDB.AttributeValue]].self,
+            from: Data(contentsOf: url)
+        )
+    }
+
+    private func canonical(
+        _ item: [String: DynamoDB.AttributeValue]
+    ) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(item), as: UTF8.self)
+    }
+
+    @Test func sectionItemMatchesTheContractFixture() throws {
+        let fixture = try loadFixture()
+        let section = ReceiptSectionPayload(
+            sectionType: "ITEMS",
+            lineIds: [3, 4],
+            rowIds: [3],
+            confidence: 0.95,
+            modelSource: swiftWorkerModelSource,
+            extractorVersion: swiftWorkerExtractorVersion
+        )
+        let item = ReceiptStructureItems.sectionItem(
+            imageId: Self.imageId, receiptId: 1,
+            section: section, createdAt: Self.fixtureTimestamp
+        )
+        #expect(
+            try canonical(item) == canonical(try #require(fixture["section"]))
+        )
+    }
+
+    @Test func lineItemItemMatchesTheContractFixture() throws {
+        let fixture = try loadFixture()
+        let payload = ReceiptLineItemPayload(
+            itemIndex: 0,
+            name: "ORGANIC",
+            price: 3.99,
+            quantity: 2.0,
+            unitPrice: 1.99,
+            isDiscount: false,
+            nameQuality: "ok",
+            lineIds: [3],
+            reconciliationStatus: "match",
+            modelSource: swiftWorkerModelSource,
+            extractorVersion: swiftWorkerExtractorVersion,
+            rawText: "ORGANIC 3.99"
+        )
+        let item = ReceiptStructureItems.lineItemItem(
+            imageId: Self.imageId, receiptId: 1,
+            item: payload, extractedAt: Self.fixtureTimestamp,
+            baselineFiguresAgreeing: 2
+        )
+        #expect(
+            try canonical(item)
+                == canonical(try #require(fixture["line_item"]))
+        )
+    }
+
+    @Test func optionalFieldsAreOmittedNotNulled() throws {
+        let payload = ReceiptLineItemPayload(
+            itemIndex: 1,
+            name: "",
+            price: 1.5,
+            quantity: nil,
+            unitPrice: nil,
+            isDiscount: false,
+            nameQuality: "low",
+            lineIds: [7],
+            reconciliationStatus: "no-baseline",
+            modelSource: swiftWorkerModelSource,
+            extractorVersion: swiftWorkerExtractorVersion,
+            rawText: nil
+        )
+        let item = ReceiptStructureItems.lineItemItem(
+            imageId: Self.imageId, receiptId: 1,
+            item: payload, extractedAt: Self.fixtureTimestamp,
+            baselineFiguresAgreeing: nil
+        )
+        #expect(item["quantity"] == nil)
+        #expect(item["unit_price"] == nil)
+        #expect(item["baseline_figures_agreeing"] == nil)
+        // The sparse merchant GSI must never appear on worker rows.
+        #expect(item["GSI1PK"] == nil)
+        #expect(item["GSI1SK"] == nil)
+        if case .s(let raw)? = item["raw_text"] {
+            #expect(raw == "")
+        } else {
+            Issue.record("raw_text must serialize as an empty string")
+        }
+        if case .s(let price)? = item["price"] {
+            #expect(price == "1.50")
+        } else {
+            Issue.record("price must serialize as a 2-decimal string")
+        }
+    }
+}

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_dynamo_items_contract.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/swift_dynamo_items_contract.json
@@ -1,0 +1,34 @@
+{
+  "section": {
+    "PK": { "S": "IMAGE#12345678-1234-4123-8123-123456789012" },
+    "SK": { "S": "RECEIPT#00001#SECTION#ITEMS" },
+    "TYPE": { "S": "RECEIPT_SECTION" },
+    "section_type": { "S": "ITEMS" },
+    "line_ids": { "L": [{ "N": "3" }, { "N": "4" }] },
+    "created_at": { "S": "2026-08-11T00:00:00.000+00:00" },
+    "confidence": { "N": "0.95" },
+    "model_source": { "S": "swift-worker-v1" },
+    "validation_status": { "S": "PENDING" },
+    "row_ids": { "L": [{ "N": "3" }] }
+  },
+  "line_item": {
+    "PK": { "S": "IMAGE#12345678-1234-4123-8123-123456789012" },
+    "SK": { "S": "RECEIPT#00001#LINE_ITEM#00000" },
+    "TYPE": { "S": "RECEIPT_LINE_ITEM" },
+    "name": { "S": "ORGANIC" },
+    "price": { "S": "3.99" },
+    "line_ids": { "L": [{ "N": "3" }] },
+    "extractor_version": { "S": "swift-worker-v1+line-items-blocks-v2" },
+    "extracted_at": { "S": "2026-08-11T00:00:00.000+00:00" },
+    "is_discount": { "BOOL": false },
+    "collapsed_banding": { "BOOL": false },
+    "name_quality": { "S": "ok" },
+    "raw_text": { "S": "ORGANIC 3.99" },
+    "source_section_status": { "S": "PENDING" },
+    "source_model_source": { "S": "swift-worker-v1" },
+    "reconciliation_status": { "S": "match" },
+    "quantity": { "N": "2.0" },
+    "unit_price": { "N": "1.99" },
+    "baseline_figures_agreeing": { "N": "2" }
+  }
+}

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
@@ -365,6 +365,15 @@ final class OCRResultContractTests: XCTestCase {
         func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws {
             wordLabels.append(contentsOf: labels)
         }
+        func addReceiptSections(
+            imageId: String, receiptId: Int,
+            sections: [ReceiptSectionPayload], createdAt: Date
+        ) async throws {}
+        func addReceiptLineItems(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws {}
     }
 
     /// Engine that "produces" the shared contract fixture plus the warped

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRResultContractTests.swift
@@ -374,6 +374,11 @@ final class OCRResultContractTests: XCTestCase {
             items: [ReceiptLineItemPayload], extractedAt: Date,
             baselineFiguresAgreeing: Int?
         ) async throws {}
+        func addReceiptLineItemsIfWorkerOwned(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws -> Int { 0 }
     }
 
     /// Engine that "produces" the shared contract fixture plus the warped

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRWorkerPoisonMessageTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRWorkerPoisonMessageTests.swift
@@ -64,6 +64,11 @@ import CoreGraphics
             items: [ReceiptLineItemPayload], extractedAt: Date,
             baselineFiguresAgreeing: Int?
         ) async throws {}
+        func addReceiptLineItemsIfWorkerOwned(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws -> Int { 0 }
     }
 
     struct StubOCREngine: OCREngineProtocol {

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRWorkerPoisonMessageTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/OCRWorkerPoisonMessageTests.swift
@@ -55,6 +55,15 @@ import CoreGraphics
         }
         func addOCRRoutingDecision(_ decision: OCRRoutingDecision) async throws {}
         func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws {}
+        func addReceiptSections(
+            imageId: String, receiptId: Int,
+            sections: [ReceiptSectionPayload], createdAt: Date
+        ) async throws {}
+        func addReceiptLineItems(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws {}
     }
 
     struct StubOCREngine: OCREngineProtocol {

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReOCRWorkerStrategyTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReOCRWorkerStrategyTests.swift
@@ -119,6 +119,15 @@ import CoreGraphics
         }
         func addOCRRoutingDecision(_ decision: OCRRoutingDecision) async throws { routing.append(decision) }
         func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws { wordLabels.append(contentsOf: labels) }
+        func addReceiptSections(
+            imageId: String, receiptId: Int,
+            sections: [ReceiptSectionPayload], createdAt: Date
+        ) async throws {}
+        func addReceiptLineItems(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws {}
     }
 
     /// Captures the image URLs the worker hands to Vision OCR so tests can

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReOCRWorkerStrategyTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReOCRWorkerStrategyTests.swift
@@ -128,6 +128,11 @@ import CoreGraphics
             items: [ReceiptLineItemPayload], extractedAt: Date,
             baselineFiguresAgreeing: Int?
         ) async throws {}
+        func addReceiptLineItemsIfWorkerOwned(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws -> Int { 0 }
     }
 
     /// Captures the image URLs the worker hands to Vision OCR so tests can

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SinglePassRedeliveryTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SinglePassRedeliveryTests.swift
@@ -6,10 +6,12 @@ import Testing
 #if os(macOS)
 import CoreGraphics
 
-/// The worker's direct line-item write must not run when the job it is
-/// processing had already COMPLETED — that delivery is a duplicate of work the
-/// cloud pipeline already ingested and may have enriched, and the worker's
-/// sparse payload would replace the enrichment.
+/// The worker's direct line-item write must never replace a row the cloud
+/// pipeline owns: that row may carry enrichment the worker's sparse payload
+/// would erase. The per-row ownership condition is the guarantee, so the
+/// single-pass write always goes through the conditional surface; the
+/// COMPLETED-at-fetch-time skip is only a fast path around a delivery whose
+/// puts would all be rejected anyway.
 /// Uses swift-testing so the suite also runs under CommandLineTools.
 @Suite struct SinglePassRedeliveryTests {
 
@@ -37,7 +39,10 @@ import CoreGraphics
 
     final class DynamoMock: DynamoClientProtocol {
         var jobs: [String: OCRJob] = [:] // "imageId:jobId"
+        /// Conditional (worker-owned) puts — the single-pass path.
         var lineItemCalls: [(imageId: String, receiptId: Int, count: Int)] = []
+        /// Unconditional puts — must stay empty for single-pass work.
+        var unconditionalLineItemCalls: [(imageId: String, receiptId: Int, count: Int)] = []
         var sectionCalls: [(imageId: String, receiptId: Int)] = []
         func getOCRJob(imageId: String, jobId: String) async throws -> OCRJob {
             guard let job = jobs["\(imageId):\(jobId)"] else {
@@ -60,7 +65,15 @@ import CoreGraphics
             items: [ReceiptLineItemPayload], extractedAt: Date,
             baselineFiguresAgreeing: Int?
         ) async throws {
+            unconditionalLineItemCalls.append((imageId, receiptId, items.count))
+        }
+        func addReceiptLineItemsIfWorkerOwned(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws -> Int {
             lineItemCalls.append((imageId, receiptId, items.count))
+            return 0
         }
     }
 
@@ -137,7 +150,12 @@ import CoreGraphics
         return (sqs, s3, dynamo, worker)
     }
 
-    @Test func pendingJobWritesLineItems() async throws {
+    /// The PENDING path writes, and it writes through the CONDITIONAL
+    /// surface: a first attempt that crashed after sending its results
+    /// message but before marking the job COMPLETED also arrives here, so
+    /// the per-row ownership condition — not the status check — is what
+    /// keeps cloud-enriched rows intact.
+    @Test func pendingJobWritesLineItemsConditionally() async throws {
         let (sqs, _, dynamo, worker) = makeFixture(status: .pending)
 
         let hadMessages = try await worker.processBatch()
@@ -146,6 +164,9 @@ import CoreGraphics
         #expect(dynamo.lineItemCalls.count == 1)
         #expect(dynamo.lineItemCalls.first?.imageId == "img-1")
         #expect((dynamo.lineItemCalls.first?.count ?? 0) > 0)
+        // Never the unconditional surface — that one belongs to the
+        // summary-refine pass, which runs after the cloud pipeline.
+        #expect(dynamo.unconditionalLineItemCalls.isEmpty)
         #expect(sqs.deleted.map(\.id) == ["m1"])
     }
 
@@ -158,6 +179,7 @@ import CoreGraphics
         // but the batch still finishes and the duplicate leaves the queue.
         #expect(hadMessages)
         #expect(dynamo.lineItemCalls.isEmpty)
+        #expect(dynamo.unconditionalLineItemCalls.isEmpty)
         #expect(sqs.deleted.map(\.id) == ["m1"])
         #expect(sqs.sentMessages.count == 1)
     }

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SinglePassRedeliveryTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/SinglePassRedeliveryTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+
+@testable import ReceiptOCRCore
+
+#if os(macOS)
+import CoreGraphics
+
+/// The worker's direct line-item write must not run when the job it is
+/// processing had already COMPLETED — that delivery is a duplicate of work the
+/// cloud pipeline already ingested and may have enriched, and the worker's
+/// sparse payload would replace the enrichment.
+/// Uses swift-testing so the suite also runs under CommandLineTools.
+@Suite struct SinglePassRedeliveryTests {
+
+    final class SQSMock: SQSClientProtocol {
+        var messages: [SQSMessage] = []
+        var sentMessages: [String] = []
+        var deleted: [SQSDeleteEntry] = []
+        func receiveMessages(queueURL: String, maxNumber: Int, visibilityTimeout: Int) async throws -> [SQSMessage] { messages }
+        func deleteMessages(queueURL: String, entries: [SQSDeleteEntry]) async throws {
+            deleted.append(contentsOf: entries)
+        }
+        func sendMessage(queueURL: String, body: String) async throws { sentMessages.append(body) }
+    }
+
+    final class S3Mock: S3ClientProtocol {
+        var objects: [String: Data] = [:] // "bucket:key" -> Data
+        func getObject(bucket: String, key: String) async throws -> Data {
+            guard let data = objects["\(bucket):\(key)"] else {
+                throw ObjectNotFoundError(bucket: bucket, key: key)
+            }
+            return data
+        }
+        func uploadFile(url: URL, bucket: String, key: String) async throws {}
+    }
+
+    final class DynamoMock: DynamoClientProtocol {
+        var jobs: [String: OCRJob] = [:] // "imageId:jobId"
+        var lineItemCalls: [(imageId: String, receiptId: Int, count: Int)] = []
+        var sectionCalls: [(imageId: String, receiptId: Int)] = []
+        func getOCRJob(imageId: String, jobId: String) async throws -> OCRJob {
+            guard let job = jobs["\(imageId):\(jobId)"] else {
+                throw DynamoMapError.missing("item")
+            }
+            return job
+        }
+        func updateOCRJob(_ job: OCRJob) async throws { jobs["\(job.imageId):\(job.jobId)"] = job }
+        func updateOCRJobStage(imageId: String, jobId: String, stage: String) async throws {}
+        func addOCRRoutingDecision(_ decision: OCRRoutingDecision) async throws {}
+        func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws {}
+        func addReceiptSections(
+            imageId: String, receiptId: Int,
+            sections: [ReceiptSectionPayload], createdAt: Date
+        ) async throws {
+            sectionCalls.append((imageId, receiptId))
+        }
+        func addReceiptLineItems(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws {
+            lineItemCalls.append((imageId, receiptId, items.count))
+        }
+    }
+
+    /// Emits the pinned single-pass contract fixture, whose `receipts[0]`
+    /// carries a non-empty `line_items` array — the write path under test.
+    struct FixtureOCREngine: OCREngineProtocol {
+        static var fixtureData: Data {
+            let url = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .appendingPathComponent("Fixtures/swift_single_pass_contract.json")
+            return (try? Data(contentsOf: url)) ?? Data()
+        }
+
+        func process(images: [URL], outputDirectory: URL, includeClassification: Bool) throws -> [URL] {
+            try images.map { url in
+                let out = outputDirectory.appendingPathComponent(
+                    url.deletingPathExtension().lastPathComponent + ".json"
+                )
+                try Self.fixtureData.write(to: out)
+                return out
+            }
+        }
+    }
+
+    private func makeConfig() -> Config {
+        Config(
+            ocrJobQueueURL: "q1",
+            ocrResultsQueueURL: "q2",
+            dynamoTableName: "tbl",
+            region: "us-west-2",
+            localstackEndpoint: nil,
+            logLevel: "error",
+            rawBucketName: "test-bucket"
+        )
+    }
+
+    /// Queues one single-pass job in the given status and returns the mocks.
+    private func makeFixture(status: OCRStatus) -> (SQSMock, S3Mock, DynamoMock, OCRWorker) {
+        let sqs = SQSMock()
+        let s3 = S3Mock()
+        let dynamo = DynamoMock()
+        let imageId = "img-1"
+        let jobId = "job-1"
+        sqs.messages = [
+            SQSMessage(
+                messageId: "m1",
+                receiptHandle: "rh-m1",
+                body: "{\"image_id\":\"\(imageId)\",\"job_id\":\"\(jobId)\"}"
+            )
+        ]
+        let now = Date()
+        dynamo.jobs["\(imageId):\(jobId)"] = OCRJob(
+            imageId: imageId,
+            jobId: jobId,
+            s3Bucket: "b",
+            s3Key: "raw/\(imageId).png",
+            createdAt: now,
+            updatedAt: now,
+            status: status
+        )
+        s3.objects["b:raw/\(imageId).png"] = ReOCRTestImages.pngData(
+            from: ReOCRTestImages.makeImage(width: 10, height: 10) { ctx in
+                ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+                ctx.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+            }
+        )
+        let worker = OCRWorker(
+            config: makeConfig(),
+            ocr: FixtureOCREngine(),
+            sqs: sqs,
+            s3: s3,
+            dynamo: dynamo
+        )
+        return (sqs, s3, dynamo, worker)
+    }
+
+    @Test func pendingJobWritesLineItems() async throws {
+        let (sqs, _, dynamo, worker) = makeFixture(status: .pending)
+
+        let hadMessages = try await worker.processBatch()
+
+        #expect(hadMessages)
+        #expect(dynamo.lineItemCalls.count == 1)
+        #expect(dynamo.lineItemCalls.first?.imageId == "img-1")
+        #expect((dynamo.lineItemCalls.first?.count ?? 0) > 0)
+        #expect(sqs.deleted.map(\.id) == ["m1"])
+    }
+
+    @Test func redeliveredCompletedJobSkipsLineItemWrite() async throws {
+        let (sqs, _, dynamo, worker) = makeFixture(status: .completed)
+
+        let hadMessages = try await worker.processBatch()
+
+        // No write over rows the cloud pipeline may already have enriched,
+        // but the batch still finishes and the duplicate leaves the queue.
+        #expect(hadMessages)
+        #expect(dynamo.lineItemCalls.isEmpty)
+        #expect(sqs.deleted.map(\.id) == ["m1"])
+        #expect(sqs.sentMessages.count == 1)
+    }
+}
+#endif

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/WorkerTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/WorkerTests.swift
@@ -38,6 +38,15 @@ final class WorkerTests: XCTestCase {
         }
         func addOCRRoutingDecision(_ decision: OCRRoutingDecision) async throws { routing.append(decision) }
         func addReceiptWordLabels(_ labels: [ReceiptWordLabel]) async throws { wordLabels.append(contentsOf: labels) }
+        func addReceiptSections(
+            imageId: String, receiptId: Int,
+            sections: [ReceiptSectionPayload], createdAt: Date
+        ) async throws {}
+        func addReceiptLineItems(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws {}
     }
 
     struct TestOCREngine: OCREngineProtocol {

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/WorkerTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/WorkerTests.swift
@@ -47,6 +47,11 @@ final class WorkerTests: XCTestCase {
             items: [ReceiptLineItemPayload], extractedAt: Date,
             baselineFiguresAgreeing: Int?
         ) async throws {}
+        func addReceiptLineItemsIfWorkerOwned(
+            imageId: String, receiptId: Int,
+            items: [ReceiptLineItemPayload], extractedAt: Date,
+            baselineFiguresAgreeing: Int?
+        ) async throws -> Int { 0 }
     }
 
     struct TestOCREngine: OCREngineProtocol {


### PR DESCRIPTION
## What

Tier 2 of the worker-authority migration (stacked on #1394). The Swift worker's Dynamo protocol could write exactly one receipt entity type (`ReceiptWordLabel`); everything structural traveled as S3 JSON for a cloud Lambda to persist. This PR gives the worker a real write surface and wires the first caller.

- **`ReceiptStructureItems`** — item serialization mirroring the Python entity writers exactly: PK/SK formats, 2-decimal price strings, sparse-GSI omission for merchant-less worker rows, `BOOL`/`L`/`N` attribute encoding via Soto's `AttributeValue`.
- **`DynamoClientProtocol`** gains `addReceiptSections` / `addReceiptLineItems`; `SotoDynamoClient` implements both over a shared chunked batch-put with unprocessed-item retry (refactored out of the labels write path).
- **`OCRWorker` writes its decoded line items directly** at single-pass time, best-effort like labels; ingest's delete-then-add over the same JSON payload remains the staleness reconciler of record.
- **Sections are deliberately NOT written at single-pass time**: a section write before the receipt's words exist would fire the stream's canonical-ITEMS trigger and cause a premature cloud recompute against a word-less receipt. `addReceiptSections` exists for the Tier-3 summary-refine pass, which runs after words + summary exist.

## Contract

Pinned on both sides via the shared fixture `swift_dynamo_items_contract.json`:
- Swift: `DynamoItemContractTests` asserts the serializer reproduces the fixture **byte-for-byte** (sorted-key JSON equality), plus sparse-field omission coverage.
- Python: `test_swift_dynamo_items_contract.py` asserts `item_to_receipt_section` / `item_to_receipt_line_item` parse it into valid entities, and that re-serializing through the Python writers reproduces the fixture (timestamps compared semantically — Swift writes `.000` millis, Python's `isoformat()` omits zero microseconds; `fromisoformat` parses both).

## Verification

- `swift build` + all 44 swift-testing suites pass (3 parity gates + new contract suite)
- All 20 Python handler contract tests pass
- `docs/architecture/mac-ocr-aws-handoff.md` updated with the new write and its best-effort semantics

Tier 3 (second worker pass on summary arrival, consuming `addReceiptSections` + this write path) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)