### PR TITLE
chore(cost): right-size compaction Lambda, batch harder, drop paid VPC endpoints

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -244,48 +244,11 @@ dynamodb_gateway_endpoint = aws.ec2.VpcEndpoint(
     route_table_ids=[public_vpc.public_route_table_id, nat.private_rt.id],
 )
 
-# CloudWatch Logs Interface Endpoint for faster logging from VPC Lambdas
-# Single AZ for cost savings ($0.12/day savings per endpoint)
-# Lambda functions can access endpoints from any AZ in the VPC
-# If endpoint AZ fails, Lambda falls back to NAT (slower but works)
+# Logs/SQS Interface Endpoints removed: VPC Lambdas reach both services via
+# the NAT instance (no per-hour endpoint charge; NAT instances have no data
+# processing fee). Gateway endpoints above stay — they're free.
 # Get stack name for conditional logic (reused later in file)
 stack = pulumi.get_stack()
-# Use single AZ for both dev and prod - AZ failures are rare (< 0.1%)
-# and Lambda functions have fallback to NAT Instance
-logs_endpoint_subnets = public_vpc.public_subnet_ids.apply(
-    lambda ids: [ids[0]]
-)  # Single AZ
-
-logs_interface_endpoint = aws.ec2.VpcEndpoint(
-    f"logs-interface-{pulumi.get_stack()}",
-    vpc_id=public_vpc.vpc_id,
-    service_name=f"com.amazonaws.{aws.config.region}.logs",
-    vpc_endpoint_type="Interface",
-    # Conditional: single AZ for dev, multi-AZ for prod
-    subnet_ids=logs_endpoint_subnets,
-    security_group_ids=[security.sg_vpce_id],
-    private_dns_enabled=True,
-)
-
-# SQS Interface Endpoint for cost-effective SQS access from both public and private subnets
-# Keep upload Lambdas private while allowing SQS access without internet.
-# Single AZ for cost savings ($0.12/day savings)
-# Lambda functions can access endpoints from any AZ in the VPC
-# If endpoint AZ fails, Lambda falls back to NAT (slower but works)
-sqs_endpoint_subnets = public_vpc.public_subnet_ids.apply(
-    lambda ids: [ids[0]]
-)  # Single AZ
-
-sqs_interface_endpoint = aws.ec2.VpcEndpoint(
-    f"sqs-interface-{pulumi.get_stack()}",
-    vpc_id=public_vpc.vpc_id,
-    service_name=f"com.amazonaws.{aws.config.region}.sqs",
-    vpc_endpoint_type="Interface",
-    # Conditional: single AZ for dev, multi-AZ for prod
-    subnet_ids=sqs_endpoint_subnets,
-    security_group_ids=[security.sg_vpce_id],
-    private_dns_enabled=True,
-)
 
 # Word Similarity Cache Generator Lambda (in VPC for DynamoDB Gateway endpoint access)
 # This reduces DynamoDB query latency variance by using AWS backbone instead of public internet

--- a/infra/chromadb_compaction/components/lambda_functions.py
+++ b/infra/chromadb_compaction/components/lambda_functions.py
@@ -136,13 +136,14 @@ class HybridLambdaDeployment(ComponentResource):
                 # 15 min allows draining large backlogs in one invocation.
                 # Must match SQS visibility timeout.
                 "timeout": 900,  # 15 minutes - must match visibility timeout
-                # Increased memory to 10240MB (10GB, Lambda max) due to OOM errors:
-                # - ChromaDB collection with ~70K embeddings uses ~8GB
-                # - Snapshot validation downloads and loads full collection
-                # - Standard queue batching processes up to 1000 messages per invocation
-                "memory_size": 10240,  # 10GB (Lambda max) for large collections
-                # Increased ephemeral storage from 5GB to 10GB for large snapshot operations
-                "ephemeral_storage": 10240,  # 10GB for ChromaDB snapshots (largest seen: 552MB)
+                # Right-sized from 10240MB after the Chroma Cloud migration:
+                # observed @maxMemoryUsed over 14 days of heavy backfill traffic
+                # (Jul 28 - Aug 10) peaked at 2.8GB with a ~650MB average, so
+                # 4096MB leaves ~1.5x headroom over the worst observed batch.
+                # The old 10GB sizing dated from loading full local collections,
+                # which no longer happens with Chroma Cloud dual-write.
+                "memory_size": 4096,
+                "ephemeral_storage": 2048,  # ChromaDB snapshots (largest seen: 552MB)
                 # Must equal the sum of the two event source mappings'
                 # maximum_concurrency (2 lines + 2 words).  Standard-queue ESMs
                 # cannot go below 2, so reserved=2 left half the poller slots
@@ -922,7 +923,10 @@ class HybridLambdaDeployment(ComponentResource):
             event_source_arn=chromadb_queues.lines_queue_arn,
             function_name=self.enhanced_compaction_function.arn,
             batch_size=1000,  # Standard queues support up to 10,000
-            maximum_batching_window_in_seconds=5,  # Batch for up to 5 seconds
+            # 60s window: compaction is background work with no latency SLA,
+            # and trickle traffic at a 5s window produced thousands of
+            # near-empty 4GB invocations per day during backfill sessions.
+            maximum_batching_window_in_seconds=60,
             function_response_types=["ReportBatchItemFailures"],
             # Minimum for standard queues is 2.  Combined with the
             # Lambda's reserved_concurrent_executions=2, each queue
@@ -938,7 +942,8 @@ class HybridLambdaDeployment(ComponentResource):
             event_source_arn=chromadb_queues.words_queue_arn,
             function_name=self.enhanced_compaction_function.arn,
             batch_size=1000,  # Standard queues support up to 10,000
-            maximum_batching_window_in_seconds=5,  # Batch for up to 5 seconds
+            # 60s window: see lines mapping above.
+            maximum_batching_window_in_seconds=60,
             function_response_types=["ReportBatchItemFailures"],
             scaling_config=aws.lambda_.EventSourceMappingScalingConfigArgs(
                 maximum_concurrency=2,


### PR DESCRIPTION
## Why

AWS cost review (May–Aug 2026). August is pacing ~$230/mo on Lambda alone, and 96% of that is the two `chromadb-*-docker-*` compaction Lambdas running at 10GB while CloudWatch REPORT lines over 14 days of heavy backfill traffic show **avg ~650MB, max 2.8GB** actually used. The 10GB sizing predates the Chroma Cloud migration (no more full local collection loads).

## Changes

1. **Compaction docker Lambda**: memory 10240 → 4096 MB, ephemeral storage 10240 → 2048 MB (largest snapshot ever seen: 552MB). Expected ~60% cut on the dominant Lambda line item (~$120–140/mo at recent pace). Note: less memory = fewer vCPUs, so durations will rise somewhat; watch avg duration + any OOM after deploy.
2. **SQS event source mappings (words/lines)**: max batching window 5s → 60s. Compaction is background work with no latency SLA; trickle traffic was spawning ~2k near-empty invocations/day per env.
3. **Remove Logs + SQS interface VPC endpoints** (dev+prod, ~$30/mo). The endpoint comments already documented NAT fallback; the t4g.nano NAT instances (no data-processing fee) carry this traffic fine. Free S3/DynamoDB gateway endpoints unchanged.

## Rollback signals

- OOM / `CompactionLockAcquisitionFailed` alarms or DLQ-less retry storms → bump memory to 6144 first.
- SQS/Logs timeouts from VPC Lambdas after endpoint removal → re-add the endpoint for that service.

## Not in this PR (phase 2 candidates from the same review)

- `combine_receipts_step_functions`, `label-evaluator-prod`, `merge_receipt` (prod): zero invocations in 60 days, but removal touches stack exports/stateful buckets — separate PR.
- LangSmith export components look idle but feed the QA-agent EMR analytics path — **not** dead.
- Console/ops items (support plan, idle EIP, log retention, orphaned pre-Pulumi Lambdas) tracked outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)