### PR TITLE
feat(portfolio): ImageBitmap ink cache for SynthesisPipeline (stack)

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -40,8 +40,10 @@ import {
   WEIGHT_STEP,
 } from "./pipelineData";
 import styles from "./SynthesisPipeline.module.css";
+import { getKnockedOutInkBitmap } from "./inkCache";
 import {
   knockOutAndBlit,
+  knockOutReceiptPaperFast,
   stampThermalDotsAndBlit,
 } from "./wasm/kernels";
 
@@ -125,26 +127,61 @@ const ReceiptInkLayer: React.FC<ReceiptInkLayerProps> = ({
       return;
     }
     let cancelled = false;
-    const source = new Image();
-    source.decoding = "async";
-    source.onload = () => {
-      if (cancelled) {
-        return;
-      }
-      const ctx = canvas.getContext("2d", { willReadFrequently: true });
+
+    const paintBitmap = (bitmap: ImageBitmap, width: number, height: number) => {
+      // Display canvas is write-only — no willReadFrequently / getImageData.
+      const ctx = canvas.getContext("2d");
       if (!ctx) {
         return;
       }
-      canvas.width = source.naturalWidth;
-      canvas.height = source.naturalHeight;
-      ctx.drawImage(source, 0, 0);
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      void knockOutAndBlit(ctx, imageData, () => cancelled);
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+      ctx.clearRect(0, 0, width, height);
+      ctx.drawImage(bitmap, 0, 0);
     };
-    source.src = src;
+
+    const fallbackImagePath = () => {
+      const source = new Image();
+      source.decoding = "async";
+      source.onload = () => {
+        if (cancelled) {
+          return;
+        }
+        const ctx = canvas.getContext("2d", { willReadFrequently: true });
+        if (!ctx) {
+          return;
+        }
+        canvas.width = source.naturalWidth;
+        canvas.height = source.naturalHeight;
+        ctx.drawImage(source, 0, 0);
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        void knockOutAndBlit(ctx, imageData, () => cancelled);
+      };
+      source.src = src;
+      return () => {
+        source.onload = null;
+      };
+    };
+
+    let disposeFallback: (() => void) | undefined;
+    void getKnockedOutInkBitmap(src, async (pixels) => {
+      await knockOutReceiptPaperFast(pixels);
+    }).then((entry) => {
+      if (cancelled) {
+        return;
+      }
+      if (entry) {
+        paintBitmap(entry.bitmap, entry.width, entry.height);
+        return;
+      }
+      disposeFallback = fallbackImagePath();
+    });
+
     return () => {
       cancelled = true;
-      source.onload = null;
+      disposeFallback?.();
     };
   }, [src]);
 

--- a/portfolio/components/ui/Figures/SynthesisPipeline/inkCache.test.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/inkCache.test.ts
@@ -1,0 +1,58 @@
+import {
+  __clearInkCacheForTests,
+  getKnockedOutInkBitmap,
+} from "./inkCache";
+
+afterEach(() => {
+  __clearInkCacheForTests();
+  jest.restoreAllMocks();
+});
+
+test("getKnockedOutInkBitmap returns null when ImageBitmap is unavailable", async () => {
+  const original = global.createImageBitmap;
+  // @ts-expect-error force unavailable
+  global.createImageBitmap = undefined;
+
+  const result = await getKnockedOutInkBitmap("/x.png", async () => {});
+  expect(result).toBeNull();
+
+  global.createImageBitmap = original;
+});
+
+test("getKnockedOutInkBitmap caches processed bitmaps per src", async () => {
+  if (typeof OffscreenCanvas === "undefined" || typeof createImageBitmap !== "function") {
+    // jsdom environment — exercise the null path only.
+    const result = await getKnockedOutInkBitmap("/missing.png", async () => {});
+    expect(result).toBeNull();
+    return;
+  }
+
+  const pixels = new Uint8ClampedArray([0, 0, 0, 255]);
+  const fakeBitmap = {
+    width: 1,
+    height: 1,
+    close: jest.fn(),
+  } as unknown as ImageBitmap;
+
+  jest.spyOn(global, "fetch").mockResolvedValue({
+    ok: true,
+    blob: async () => new Blob([pixels]),
+  } as Response);
+  jest.spyOn(global, "createImageBitmap").mockResolvedValue(fakeBitmap);
+
+  // Stub OffscreenCanvas path to avoid depending on full canvas impl.
+  const process = jest.fn(async (buf: Uint8ClampedArray) => {
+    buf[3] = 128;
+  });
+
+  // When OffscreenCanvas exists but getContext may be incomplete in jsdom,
+  // the helper should fail soft to null rather than throw.
+  const first = await getKnockedOutInkBitmap("/ink.png", process);
+  const second = await getKnockedOutInkBitmap("/ink.png", process);
+  if (first && second) {
+    expect(second).toBe(first);
+    expect(process).toHaveBeenCalledTimes(1);
+  } else {
+    expect(first).toBeNull();
+  }
+});

--- a/portfolio/components/ui/Figures/SynthesisPipeline/inkCache.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/inkCache.ts
@@ -1,0 +1,112 @@
+/**
+ * Cache knocked-out receipt ink as ImageBitmaps keyed by source URL.
+ * Avoids repeating decode + getImageData + knockout when the same print/cloud
+ * is remounted across act transitions or React Strict Mode double-effects.
+ */
+
+type CacheEntry = {
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<CacheEntry | null>>();
+
+const canUseImageBitmap = (): boolean =>
+  typeof createImageBitmap === "function" && typeof ImageBitmap !== "undefined";
+
+/**
+ * Decode `src` to pixels, run `process` (knockout), and return a transferable
+ * ImageBitmap. Falls back to null when ImageBitmap APIs are unavailable
+ * (jsdom); callers should use the canvas getImageData path instead.
+ */
+export const getKnockedOutInkBitmap = (
+  src: string,
+  process: (pixels: Uint8ClampedArray, width: number, height: number) => Promise<void>,
+): Promise<CacheEntry | null> => {
+  const hit = cache.get(src);
+  if (hit) {
+    return Promise.resolve(hit);
+  }
+  const pending = inflight.get(src);
+  if (pending) {
+    return pending;
+  }
+
+  const work = (async (): Promise<CacheEntry | null> => {
+    if (!canUseImageBitmap()) {
+      return null;
+    }
+    try {
+      const response = await fetch(src);
+      if (!response.ok) {
+        return null;
+      }
+      const blob = await response.blob();
+      const decoded = await createImageBitmap(blob);
+      const width = decoded.width;
+      const height = decoded.height;
+
+      // Prefer OffscreenCanvas so we never touch the visible canvas for readback.
+      let pixels: Uint8ClampedArray;
+      if (typeof OffscreenCanvas !== "undefined") {
+        const off = new OffscreenCanvas(width, height);
+        const ctx = off.getContext("2d", { willReadFrequently: true });
+        if (!ctx) {
+          decoded.close();
+          return null;
+        }
+        ctx.drawImage(decoded, 0, 0);
+        decoded.close();
+        const imageData = ctx.getImageData(0, 0, width, height);
+        pixels = imageData.data;
+        await process(pixels, width, height);
+        ctx.putImageData(imageData, 0, 0);
+        const bitmap = await off.transferToImageBitmap();
+        const entry = { bitmap, width, height };
+        cache.set(src, entry);
+        return entry;
+      }
+
+      // DOM canvas fallback when OffscreenCanvas is missing.
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d", { willReadFrequently: true });
+      if (!ctx) {
+        decoded.close();
+        return null;
+      }
+      ctx.drawImage(decoded, 0, 0);
+      decoded.close();
+      const imageData = ctx.getImageData(0, 0, width, height);
+      await process(imageData.data, width, height);
+      ctx.putImageData(imageData, 0, 0);
+      const bitmap = await createImageBitmap(canvas);
+      const entry = { bitmap, width, height };
+      cache.set(src, entry);
+      return entry;
+    } catch {
+      return null;
+    } finally {
+      inflight.delete(src);
+    }
+  })();
+
+  inflight.set(src, work);
+  return work;
+};
+
+/** Test-only: drop cached bitmaps. */
+export const __clearInkCacheForTests = (): void => {
+  cache.forEach((entry) => {
+    try {
+      entry.bitmap.close();
+    } catch {
+      // ignore
+    }
+  });
+  cache.clear();
+  inflight.clear();
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack
Stacked on [#1399](https://github.com/tnorlund/Portfolio/pull/1399) (`cursor/synthesis-pipeline-wasm-7a1d`).

Merge order: **#1399 → this → worker → assemble → autoplay**.

## Summary
- Decode receipt ink via `fetch` + `createImageBitmap`
- Prefer `OffscreenCanvas` for readback/knockout so the visible canvas is write-only
- Cache knocked-out `ImageBitmap`s per URL to skip repeat `getImageData` work on remounts
- Fall back to the previous `<img>` + canvas path when ImageBitmap APIs are unavailable (jsdom)

## Type of Change
- [x] Performance improvement
- [x] New feature

## Testing
- [x] `npm test -- --testPathPatterns='SynthesisPipeline|inkCache|kernels'`
- [x] `npm run type-check`
- [x] ESLint on SynthesisPipeline

## Related
Part of the SynthesisPipeline client perf stack after WASM kernels.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

