### PR TITLE
feat(portfolio): Web Worker for SynthesisPipeline kernels (stack)

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/wasm/kernels.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/wasm/kernels.ts
@@ -7,8 +7,9 @@ import {
   loadSynthesisPipelineWasm,
   SynthesisPipelineWasmExports,
 } from "./loader";
+import { knockOutInWorker, stampThermalInWorker } from "./workerClient";
 
-export type KernelPath = "wasm" | "js";
+export type KernelPath = "worker" | "wasm" | "js";
 
 let cached: SynthesisPipelineWasmExports | null | undefined;
 
@@ -41,12 +42,18 @@ const blitPixels = (
 };
 
 /**
- * Prefer WASM knock-out; fall back to the JS reference on any failure.
- * Mutates `pixels` in place in either path.
+ * Prefer worker (off main thread) → main-thread WASM → JS reference.
+ * Mutates `pixels` in place in every path.
  */
 export const knockOutReceiptPaperFast = async (
   pixels: Uint8ClampedArray,
 ): Promise<KernelPath> => {
+  const workerResult = await knockOutInWorker(pixels);
+  if (workerResult) {
+    pixels.set(workerResult.pixels);
+    return "worker";
+  }
+
   const wasm = await getWasm();
   if (!wasm) {
     knockOutJs(pixels);
@@ -90,7 +97,7 @@ export const knockOutAndBlit = async (
 };
 
 /**
- * Prefer WASM thermal stamping; blit from WASM memory when possible.
+ * Prefer worker thermal stamping; then main-thread WASM; then JS.
  */
 export const stampThermalDotsAndBlit = async (
   ctx: CanvasRenderingContext2D,
@@ -98,21 +105,29 @@ export const stampThermalDotsAndBlit = async (
   isCancelled?: () => boolean,
 ): Promise<KernelPath> => {
   const { width, height, points, count, radius, red, green, blue } = params;
+  const safeCount = Math.min(count, points.length >> 1);
+  const safeParams = { ...params, count: safeCount };
+
+  const workerResult = await stampThermalInWorker(safeParams);
+  if (workerResult) {
+    blitPixels(ctx, workerResult.pixels, width, height, isCancelled);
+    return "worker";
+  }
+
   const wasm = await getWasm();
   if (!wasm) {
     const pixels = new Uint8ClampedArray(width * height * 4);
-    stampThermalJs(pixels, params);
+    stampThermalJs(pixels, safeParams);
     blitPixels(ctx, pixels, width, height, isCancelled);
     return "js";
   }
   try {
-    const safeCount = Math.min(count, points.length >> 1);
     const pixelBytes = width * height * 4;
     const pointsBytes = safeCount * 8;
     const base = wasm.bufferBase();
     if (!wasm.ensureCapacity(pixelBytes + pointsBytes)) {
       const pixels = new Uint8ClampedArray(width * height * 4);
-      stampThermalJs(pixels, { ...params, count: safeCount });
+      stampThermalJs(pixels, safeParams);
       blitPixels(ctx, pixels, width, height, isCancelled);
       return "js";
     }
@@ -136,7 +151,7 @@ export const stampThermalDotsAndBlit = async (
     return "wasm";
   } catch {
     const pixels = new Uint8ClampedArray(width * height * 4);
-    stampThermalJs(pixels, params);
+    stampThermalJs(pixels, safeParams);
     blitPixels(ctx, pixels, width, height, isCancelled);
     return "js";
   }
@@ -144,7 +159,7 @@ export const stampThermalDotsAndBlit = async (
 
 /**
  * Prefer WASM thermal stamping into `pixels`; fall back to JS.
- * Kept for unit tests that assert buffer equality.
+ * Kept for unit tests that assert buffer equality (main-thread path).
  */
 export const stampThermalDotsFast = async (
   pixels: Uint8ClampedArray,

--- a/portfolio/components/ui/Figures/SynthesisPipeline/wasm/workerClient.test.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/wasm/workerClient.test.ts
@@ -1,0 +1,40 @@
+import {
+  __resetWorkerClientForTests,
+  knockOutInWorker,
+  stampThermalInWorker,
+} from "./workerClient";
+
+afterEach(() => {
+  __resetWorkerClientForTests();
+});
+
+test("knockOutInWorker returns null when Worker is unavailable", async () => {
+  const original = global.Worker;
+  // @ts-expect-error force unavailable in jsdom-like envs
+  global.Worker = undefined;
+
+  const result = await knockOutInWorker(new Uint8ClampedArray([0, 0, 0, 255]));
+  expect(result).toBeNull();
+
+  global.Worker = original;
+});
+
+test("stampThermalInWorker returns null when Worker is unavailable", async () => {
+  const original = global.Worker;
+  // @ts-expect-error force unavailable
+  global.Worker = undefined;
+
+  const result = await stampThermalInWorker({
+    width: 4,
+    height: 4,
+    points: new Float32Array([1, 1]),
+    count: 1,
+    radius: 1,
+    red: 0,
+    green: 0,
+    blue: 0,
+  });
+  expect(result).toBeNull();
+
+  global.Worker = original;
+});

--- a/portfolio/components/ui/Figures/SynthesisPipeline/wasm/workerClient.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/wasm/workerClient.ts
@@ -1,0 +1,150 @@
+/**
+ * Main-thread client for the SynthesisPipeline pixel worker.
+ * Falls back to null when Workers are unavailable (SSR / jsdom).
+ */
+
+export type WorkerKnockOutResult = {
+  pixels: Uint8ClampedArray;
+  via: "worker";
+};
+
+export type WorkerStampResult = {
+  pixels: Uint8ClampedArray;
+  via: "worker";
+};
+
+type Pending = {
+  resolve: (value: ArrayBuffer) => void;
+  reject: (reason: Error) => void;
+};
+
+const WORKER_URL = "/wasm/synthesis_pipeline_worker.js";
+
+let worker: Worker | null | undefined;
+let nextId = 1;
+const pending = new Map<number, Pending>();
+
+const canUseWorker = (): boolean =>
+  typeof Worker !== "undefined" && typeof window !== "undefined";
+
+const ensureWorker = (): Worker | null => {
+  if (worker !== undefined) {
+    return worker;
+  }
+  if (!canUseWorker()) {
+    worker = null;
+    return null;
+  }
+  try {
+    const instance = new Worker(WORKER_URL);
+    instance.onmessage = (event: MessageEvent) => {
+      const data = event.data as {
+        id: number;
+        ok: boolean;
+        buffer?: ArrayBuffer;
+        error?: string;
+      };
+      const entry = pending.get(data.id);
+      if (!entry) {
+        return;
+      }
+      pending.delete(data.id);
+      if (data.ok && data.buffer) {
+        entry.resolve(data.buffer);
+      } else {
+        entry.reject(new Error(data.error || "worker failed"));
+      }
+    };
+    instance.onerror = () => {
+      // Disable worker after a hard failure; callers fall back to main thread.
+      worker = null;
+      pending.forEach((p) => p.reject(new Error("worker crashed")));
+      pending.clear();
+    };
+    worker = instance;
+    return instance;
+  } catch {
+    worker = null;
+    return null;
+  }
+};
+
+const requestBuffer = (
+  instance: Worker,
+  message: Record<string, unknown>,
+  transfer: ArrayBuffer[],
+): Promise<ArrayBuffer> => {
+  const id = nextId;
+  nextId += 1;
+  return new Promise<ArrayBuffer>((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    instance.postMessage({ ...message, id }, transfer);
+  });
+};
+
+export const knockOutInWorker = async (
+  pixels: Uint8ClampedArray,
+): Promise<WorkerKnockOutResult | null> => {
+  const instance = ensureWorker();
+  if (!instance) {
+    return null;
+  }
+  try {
+    // Transfer a copy so the caller's buffer stays usable on failure paths.
+    const copy = pixels.slice().buffer;
+    const buffer = await requestBuffer(
+      instance,
+      { type: "knockOut", buffer: copy },
+      [copy],
+    );
+    return { pixels: new Uint8ClampedArray(buffer), via: "worker" };
+  } catch {
+    return null;
+  }
+};
+
+export const stampThermalInWorker = async (params: {
+  width: number;
+  height: number;
+  points: Float32Array;
+  count: number;
+  radius: number;
+  red: number;
+  green: number;
+  blue: number;
+}): Promise<WorkerStampResult | null> => {
+  const instance = ensureWorker();
+  if (!instance) {
+    return null;
+  }
+  try {
+    const pointsCopy = params.points.slice(0, params.count * 2).buffer;
+    const buffer = await requestBuffer(
+      instance,
+      {
+        type: "stampThermal",
+        width: params.width,
+        height: params.height,
+        count: params.count,
+        radius: params.radius,
+        red: params.red,
+        green: params.green,
+        blue: params.blue,
+        pointsBuffer: pointsCopy,
+      },
+      [pointsCopy],
+    );
+    return { pixels: new Uint8ClampedArray(buffer), via: "worker" };
+  } catch {
+    return null;
+  }
+};
+
+/** Test-only: reset memoized worker. */
+export const __resetWorkerClientForTests = (): void => {
+  if (worker) {
+    worker.terminate();
+  }
+  worker = undefined;
+  pending.clear();
+};

--- a/portfolio/public/wasm/synthesis_pipeline_worker.js
+++ b/portfolio/public/wasm/synthesis_pipeline_worker.js
@@ -1,0 +1,199 @@
+/**
+ * SynthesisPipeline pixel worker.
+ * Runs knockout + thermal stamp off the main thread. Prefers the committed
+ * WASM module; falls back to JS kernels inside the worker.
+ */
+"use strict";
+
+/** @type {WebAssembly.Exports | null} */
+let wasm = null;
+let wasmFailed = false;
+
+function knockOutJs(pixels) {
+  const paperLuminance = 220;
+  const solidInkLuminance = 70;
+  for (let i = 0; i < pixels.length; i += 4) {
+    const luminance = Math.round(
+      pixels[i] * 0.2126 + pixels[i + 1] * 0.7152 + pixels[i + 2] * 0.0722,
+    );
+    const normalizedInk = Math.min(
+      1,
+      Math.max(0, (paperLuminance - luminance) / (paperLuminance - solidInkLuminance)),
+    );
+    const inkAlpha = normalizedInk ** 1.5;
+    pixels[i + 3] = Math.round(pixels[i + 3] * inkAlpha);
+    pixels[i] = 0;
+    pixels[i + 1] = 0;
+    pixels[i + 2] = 0;
+  }
+}
+
+function stampThermalJs(pixels, width, height, points, count, radius, red, green, blue) {
+  pixels.fill(0);
+  if (width <= 0 || height <= 0 || count <= 0 || radius <= 0) {
+    return;
+  }
+  const outer = radius + 0.5;
+  const outer2 = outer * outer;
+  const inner = Math.max(0, radius - 0.5);
+  const inner2 = inner * inner;
+  const ir = Math.ceil(outer);
+  for (let i = 0; i < count; i += 1) {
+    const cx = points[i * 2];
+    const cy = points[i * 2 + 1];
+    const x0 = Math.max(0, Math.floor(cx - ir));
+    const x1 = Math.min(width - 1, Math.ceil(cx + ir));
+    const y0 = Math.max(0, Math.floor(cy - ir));
+    const y1 = Math.min(height - 1, Math.ceil(cy + ir));
+    for (let y = y0; y <= y1; y += 1) {
+      const dy = y + 0.5 - cy;
+      const dy2 = dy * dy;
+      for (let x = x0; x <= x1; x += 1) {
+        const dx = x + 0.5 - cx;
+        const d2 = dx * dx + dy2;
+        if (d2 > outer2) continue;
+        let coverage = 1;
+        if (d2 > inner2) {
+          coverage = Math.max(0, Math.min(1, outer - Math.sqrt(d2)));
+        }
+        const alpha = Math.round(coverage * 255);
+        if (!alpha) continue;
+        const o = (y * width + x) * 4;
+        if (alpha >= pixels[o + 3]) {
+          pixels[o] = red;
+          pixels[o + 1] = green;
+          pixels[o + 2] = blue;
+          pixels[o + 3] = alpha;
+        }
+      }
+    }
+  }
+}
+
+/** @type {Promise<WebAssembly.Exports | null> | null} */
+let wasmInit = null;
+
+async function ensureWasm() {
+  if (wasm || wasmFailed) return wasm;
+  if (!wasmInit) {
+    wasmInit = (async () => {
+      try {
+        const response = await fetch("/wasm/synthesis_pipeline.wasm");
+        if (!response.ok) {
+          wasmFailed = true;
+          return null;
+        }
+        let result;
+        try {
+          result = await WebAssembly.instantiateStreaming(response.clone());
+        } catch {
+          const buffer = await response.arrayBuffer();
+          result = await WebAssembly.instantiate(buffer);
+        }
+        wasm = result.instance.exports;
+        return wasm;
+      } catch {
+        wasmFailed = true;
+        return null;
+      }
+    })();
+  }
+  return wasmInit;
+}
+
+function knockOutWithWasm(exports, pixels) {
+  const byteLength = pixels.byteLength;
+  const base = exports.bufferBase();
+  if (!exports.ensureCapacity(byteLength)) {
+    knockOutJs(pixels);
+    return;
+  }
+  new Uint8Array(exports.memory.buffer, base, byteLength).set(pixels);
+  exports.knockOutReceiptPaper(base, byteLength);
+  pixels.set(new Uint8Array(exports.memory.buffer, base, byteLength));
+}
+
+function stampWithWasm(exports, pixels, width, height, points, count, radius, red, green, blue) {
+  const safeCount = Math.min(count, points.length >> 1);
+  const pixelBytes = width * height * 4;
+  const base = exports.bufferBase();
+  if (!exports.ensureCapacity(pixelBytes + safeCount * 8)) {
+    stampThermalJs(pixels, width, height, points, safeCount, radius, red, green, blue);
+    return;
+  }
+  const pointsPtr = base + pixelBytes;
+  new Float32Array(exports.memory.buffer, pointsPtr, safeCount * 2).set(
+    points.subarray(0, safeCount * 2),
+  );
+  exports.stampThermalDots(
+    base,
+    width,
+    height,
+    pointsPtr,
+    safeCount,
+    radius,
+    red,
+    green,
+    blue,
+  );
+  pixels.set(new Uint8Array(exports.memory.buffer, base, pixelBytes));
+}
+
+self.onmessage = async (event) => {
+  const msg = event.data || {};
+  const { id, type } = msg;
+  try {
+    if (type === "knockOut") {
+      const pixels = new Uint8ClampedArray(msg.buffer);
+      const exports = await ensureWasm();
+      if (exports) {
+        knockOutWithWasm(exports, pixels);
+      } else {
+        knockOutJs(pixels);
+      }
+      self.postMessage({ id, ok: true, buffer: pixels.buffer }, [pixels.buffer]);
+      return;
+    }
+    if (type === "stampThermal") {
+      const { width, height, count, radius, red, green, blue } = msg;
+      const points = new Float32Array(msg.pointsBuffer);
+      const pixels = new Uint8ClampedArray(width * height * 4);
+      const exports = await ensureWasm();
+      if (exports) {
+        stampWithWasm(
+          exports,
+          pixels,
+          width,
+          height,
+          points,
+          count,
+          radius,
+          red,
+          green,
+          blue,
+        );
+      } else {
+        stampThermalJs(
+          pixels,
+          width,
+          height,
+          points,
+          count,
+          radius,
+          red,
+          green,
+          blue,
+        );
+      }
+      self.postMessage({ id, ok: true, buffer: pixels.buffer }, [pixels.buffer]);
+      return;
+    }
+    self.postMessage({ id, ok: false, error: "unknown type" });
+  } catch (err) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: err && err.message ? err.message : String(err),
+    });
+  }
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack
Stacked on [#1401](https://github.com/tnorlund/Portfolio/pull/1401) (`cursor/synthesis-pipeline-bitmap-7a1d` → `#1399`).

Merge order: **#1399 → #1401 → this → assemble → autoplay**.

## Summary
- Static worker at `/wasm/synthesis_pipeline_worker.js` (works with Next `output: "export"`)
- Worker prefers WASM knockout/thermal, with JS fallback inside the worker
- Main-thread `kernels.ts` tries worker first, then main-thread WASM, then JS
- Keeps main thread free for React / rAF while pixel work runs

## Testing
- [x] Unit tests (worker unavailable → null; existing kernel parity)
- [x] `npm run type-check`
- [x] ESLint

## Related
Part of the SynthesisPipeline client perf stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

