### PR TITLE
feat(portfolio): incremental assemble canvas drawing (stack)

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -855,10 +855,45 @@ const AssembleAct: React.FC<ActProps> = ({
       });
     }
 
-    // Erase previous carets by redrawing the word under the leading edge, then
-    // optionally paint new carets. Avoids a full-canvas clear each blink.
+    // Carets are overlaid on ink. Erase at the *previous* leading edge (where
+    // the old caret was drawn), restore every revealed crop that intersects
+    // that strip, then paint carets at the new leading edge.
     const caretOn = caretVisibleAt(t);
-    const eraseCaretAt = (count: number, group: number[]) => {
+    const cropsIntersect = (
+      a: { sx: number; sy: number; sw: number; sh: number },
+      b: { sx: number; sy: number; sw: number; sh: number },
+    ): boolean =>
+      a.sx < b.sx + b.sw &&
+      a.sx + a.sw > b.sx &&
+      a.sy < b.sy + b.sh &&
+      a.sy + a.sh > b.sy;
+
+    const drawWord = (wordIndex: number) => {
+      const r = wordRects[wordIndex];
+      if (!r) {
+        return;
+      }
+      const crop = rectToCrop(r, renderW, renderH);
+      if (!crop) {
+        return;
+      }
+      ctx.drawImage(
+        img,
+        crop.sx,
+        crop.sy,
+        crop.sw,
+        crop.sh,
+        crop.sx,
+        crop.sy,
+        crop.sw,
+        crop.sh,
+      );
+    };
+
+    const eraseCaretAt = (count: number, group: number[], revealed: number) => {
+      if (group.length === 0) {
+        return;
+      }
       const idx = group[Math.min(group.length - 1, count)];
       const r = wordRects[idx];
       if (!r) {
@@ -868,30 +903,27 @@ const AssembleAct: React.FC<ActProps> = ({
       if (!crop) {
         return;
       }
-      // Clear a strip that covers the caret (4px left of the word).
-      ctx.clearRect(crop.sx - 4, crop.sy, 6, crop.sh);
-      if (count > 0) {
-        const under = wordRects[group[Math.min(group.length - 1, count - 1)]];
-        const underCrop = under ? rectToCrop(under, renderW, renderH) : null;
-        if (underCrop) {
-          ctx.drawImage(
-            img,
-            underCrop.sx,
-            underCrop.sy,
-            underCrop.sw,
-            underCrop.sh,
-            underCrop.sx,
-            underCrop.sy,
-            underCrop.sw,
-            underCrop.sh,
-          );
+      const strip = {
+        sx: crop.sx - 4,
+        sy: crop.sy,
+        sw: 6,
+        sh: crop.sh,
+      };
+      ctx.clearRect(strip.sx, strip.sy, strip.sw, strip.sh);
+      // Heal any ink the strip removed — not just the previous logical word.
+      const healThrough = Math.max(revealed, count);
+      for (let i = 0; i < healThrough && i < group.length; i += 1) {
+        const word = wordRects[group[i]];
+        const wordCrop = word ? rectToCrop(word, renderW, renderH) : null;
+        if (wordCrop && cropsIntersect(wordCrop, strip)) {
+          drawWord(group[i]);
         }
       }
     };
 
-    if (prevCaretOnRef.current || caretOn) {
+    if (prevCaretOnRef.current) {
       groups.forEach((g, gi) => {
-        eraseCaretAt(nextCounts[gi] ?? 0, g);
+        eraseCaretAt(prevCounts[gi] ?? 0, g, nextCounts[gi] ?? 0);
       });
     }
     if (caretOn) {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/Acts.tsx
@@ -40,6 +40,12 @@ import {
   WEIGHT_STEP,
 } from "./pipelineData";
 import styles from "./SynthesisPipeline.module.css";
+import {
+  caretVisibleAt,
+  newlyRevealedWordIndices,
+  rectToCrop,
+  revealedCountsForProgress,
+} from "./assembleDraw";
 import { getKnockedOutInkBitmap } from "./inkCache";
 import {
   knockOutAndBlit,
@@ -673,7 +679,9 @@ const AssembleAct: React.FC<ActProps> = ({
   const { compose, finalLabels } = assets;
   const p = reducedMotion ? 1 : progress;
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const imgRef = useRef<HTMLImageElement | null>(null);
+  const sourceRef = useRef<HTMLImageElement | ImageBitmap | null>(null);
+  const prevCountsRef = useRef<number[]>([]);
+  const prevCaretOnRef = useRef(false);
   const [imgReady, setImgReady] = useState(false);
 
   const render = finalLabels?.metadata?.render;
@@ -714,25 +722,58 @@ const AssembleAct: React.FC<ActProps> = ({
   const typingP = phase(p, TYPE_START, TYPE_END);
   const labelsShown = p >= TYPE_END + 0.06;
 
-  // Load the printed receipt once.
+  // Load the printed receipt once (prefer ImageBitmap; fall back to <img>).
   useEffect(() => {
     if (!finalLabels) {
       return;
     }
-    const img = new window.Image();
-    img.onload = () => {
-      imgRef.current = img;
-      setImgReady(true);
+    let cancelled = false;
+    const src = finalSrc(merchant);
+
+    const load = async () => {
+      if (typeof createImageBitmap === "function") {
+        try {
+          const response = await fetch(src);
+          if (response.ok) {
+            const bitmap = await createImageBitmap(await response.blob());
+            if (cancelled) {
+              bitmap.close();
+              return;
+            }
+            sourceRef.current = bitmap;
+            setImgReady(true);
+            return;
+          }
+        } catch {
+          // fall through to Image()
+        }
+      }
+      const img = new window.Image();
+      img.onload = () => {
+        if (cancelled) {
+          return;
+        }
+        sourceRef.current = img;
+        setImgReady(true);
+      };
+      img.src = src;
     };
-    img.src = finalSrc(merchant);
+
+    void load();
     return () => {
-      img.onload = null;
+      cancelled = true;
+      const source = sourceRef.current;
+      if (source && typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap) {
+        source.close();
+      }
+      sourceRef.current = null;
+      prevCountsRef.current = [];
+      prevCaretOnRef.current = false;
     };
   }, [merchant, finalLabels]);
 
-  // Draw the revealed words. Each group reveals in order, all groups at once, so
-  // the receipt materializes top-to-bottom in four places simultaneously; a
-  // caret blinks at each section's leading edge.
+  // Incremental typing reveal: size the canvas once, draw only newly revealed
+  // word crops, and redraw carets without wiping the whole receipt buffer.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
@@ -742,39 +783,123 @@ const AssembleAct: React.FC<ActProps> = ({
     if (!ctx) {
       return; // jsdom / no 2d context
     }
-    canvas.width = renderW;
-    canvas.height = renderH;
-    ctx.clearRect(0, 0, renderW, renderH);
-    const img = imgRef.current;
+    const sized = canvas.width !== renderW || canvas.height !== renderH;
+    if (sized) {
+      canvas.width = renderW;
+      canvas.height = renderH;
+      prevCountsRef.current = groups.map(() => 0);
+      prevCaretOnRef.current = false;
+    }
+
+    const img = sourceRef.current;
     if (!img || !imgReady) {
       return;
     }
+
     const t = clamp01(typingP);
-    const drawWordCrop = (r: ReturnType<typeof toCssRectInner>) => {
-      const sx = (r.left / 100) * renderW;
-      const sy = (r.top / 100) * renderH;
-      const sw = (r.width / 100) * renderW;
-      const sh = (r.height / 100) * renderH;
-      if (sw > 0 && sh > 0) {
-        ctx.drawImage(img, sx, sy, sw, sh, sx, sy, sw, sh);
+    const nextCounts = revealedCountsForProgress(groups, t);
+    const prevCounts = prevCountsRef.current.length
+      ? prevCountsRef.current
+      : groups.map(() => 0);
+
+    // Progress went backwards (act restart / scrub) — full redraw.
+    const wentBackwards = nextCounts.some((n, i) => n < (prevCounts[i] ?? 0));
+    if (wentBackwards || sized) {
+      ctx.clearRect(0, 0, renderW, renderH);
+      const full = newlyRevealedWordIndices(
+        groups,
+        groups.map(() => 0),
+        nextCounts,
+      );
+      full.forEach((wordIndex) => {
+        const r = wordRects[wordIndex];
+        if (!r) {
+          return;
+        }
+        const crop = rectToCrop(r, renderW, renderH);
+        if (crop) {
+          ctx.drawImage(
+            img,
+            crop.sx,
+            crop.sy,
+            crop.sw,
+            crop.sh,
+            crop.sx,
+            crop.sy,
+            crop.sw,
+            crop.sh,
+          );
+        }
+      });
+    } else {
+      const delta = newlyRevealedWordIndices(groups, prevCounts, nextCounts);
+      delta.forEach((wordIndex) => {
+        const r = wordRects[wordIndex];
+        if (!r) {
+          return;
+        }
+        const crop = rectToCrop(r, renderW, renderH);
+        if (crop) {
+          ctx.drawImage(
+            img,
+            crop.sx,
+            crop.sy,
+            crop.sw,
+            crop.sh,
+            crop.sx,
+            crop.sy,
+            crop.sw,
+            crop.sh,
+          );
+        }
+      });
+    }
+
+    // Erase previous carets by redrawing the word under the leading edge, then
+    // optionally paint new carets. Avoids a full-canvas clear each blink.
+    const caretOn = caretVisibleAt(t);
+    const eraseCaretAt = (count: number, group: number[]) => {
+      const idx = group[Math.min(group.length - 1, count)];
+      const r = wordRects[idx];
+      if (!r) {
+        return;
       }
-    };
-    groups.forEach((g) => {
-      const revealed = Math.round(t * g.length);
-      for (let i = 0; i < revealed; i += 1) {
-        const r = wordRects[g[i]];
-        if (r) {
-          drawWordCrop(r);
+      const crop = rectToCrop(r, renderW, renderH);
+      if (!crop) {
+        return;
+      }
+      // Clear a strip that covers the caret (4px left of the word).
+      ctx.clearRect(crop.sx - 4, crop.sy, 6, crop.sh);
+      if (count > 0) {
+        const under = wordRects[group[Math.min(group.length - 1, count - 1)]];
+        const underCrop = under ? rectToCrop(under, renderW, renderH) : null;
+        if (underCrop) {
+          ctx.drawImage(
+            img,
+            underCrop.sx,
+            underCrop.sy,
+            underCrop.sw,
+            underCrop.sh,
+            underCrop.sx,
+            underCrop.sy,
+            underCrop.sw,
+            underCrop.sh,
+          );
         }
       }
-    });
-    // Blinking carets at each leading edge while typing.
-    if (t > 0 && t < 1 && Math.floor(t * 48) % 2 === 0) {
+    };
+
+    if (prevCaretOnRef.current || caretOn) {
+      groups.forEach((g, gi) => {
+        eraseCaretAt(nextCounts[gi] ?? 0, g);
+      });
+    }
+    if (caretOn) {
       ctx.fillStyle =
         getComputedStyle(canvas).getPropertyValue("--color-blue").trim() ||
         "#4a90d9";
-      groups.forEach((g) => {
-        const revealed = Math.round(t * g.length);
+      groups.forEach((g, gi) => {
+        const revealed = nextCounts[gi] ?? 0;
         const r = wordRects[g[Math.min(g.length - 1, revealed)]];
         if (r) {
           ctx.fillRect(
@@ -786,6 +911,9 @@ const AssembleAct: React.FC<ActProps> = ({
         }
       });
     }
+
+    prevCountsRef.current = nextCounts;
+    prevCaretOnRef.current = caretOn;
   }, [typingP, imgReady, groups, wordRects, renderW, renderH]);
 
   if (!finalLabels || !compose) {

--- a/portfolio/components/ui/Figures/SynthesisPipeline/assembleDraw.test.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/assembleDraw.test.ts
@@ -1,0 +1,38 @@
+import {
+  caretVisibleAt,
+  newlyRevealedWordIndices,
+  rectToCrop,
+  revealedCountsForProgress,
+} from "./assembleDraw";
+
+test("revealedCountsForProgress scales each group independently", () => {
+  expect(revealedCountsForProgress([[0, 1, 2, 3], [10, 11]], 0)).toEqual([0, 0]);
+  expect(revealedCountsForProgress([[0, 1, 2, 3], [10, 11]], 0.5)).toEqual([2, 1]);
+  expect(revealedCountsForProgress([[0, 1, 2, 3], [10, 11]], 1)).toEqual([4, 2]);
+});
+
+test("newlyRevealedWordIndices returns only the delta", () => {
+  const groups = [
+    [0, 1, 2, 3],
+    [10, 11, 12],
+  ];
+  expect(newlyRevealedWordIndices(groups, [0, 0], [2, 1])).toEqual([0, 1, 10]);
+  expect(newlyRevealedWordIndices(groups, [2, 1], [2, 1])).toEqual([]);
+  expect(newlyRevealedWordIndices(groups, [2, 1], [4, 3])).toEqual([2, 3, 11, 12]);
+});
+
+test("rectToCrop rejects empty rects", () => {
+  expect(rectToCrop({ left: 10, top: 10, width: 0, height: 5 }, 100, 100)).toBeNull();
+  expect(rectToCrop({ left: 10, top: 20, width: 25, height: 10 }, 200, 400)).toEqual({
+    sx: 20,
+    sy: 80,
+    sw: 50,
+    sh: 40,
+  });
+});
+
+test("caretVisibleAt blinks while typing", () => {
+  expect(caretVisibleAt(0)).toBe(false);
+  expect(caretVisibleAt(1)).toBe(false);
+  expect(caretVisibleAt(0.02)).toBe(true);
+});

--- a/portfolio/components/ui/Figures/SynthesisPipeline/assembleDraw.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/assembleDraw.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the assemble-act typing reveal.
+ * Kept free of React/canvas so incremental draw logic is unit-testable.
+ */
+
+export type WordRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+/** How many words each group should show at typing progress `t` (0..1). */
+export const revealedCountsForProgress = (
+  groups: number[][],
+  t: number,
+): number[] => {
+  const clamped = Math.min(1, Math.max(0, t));
+  return groups.map((g) => Math.round(clamped * g.length));
+};
+
+/**
+ * Word indices newly revealed since `prevCounts` (exclusive) up to `nextCounts`
+ * (inclusive). Used to draw only the delta instead of re-cropping every word.
+ */
+export const newlyRevealedWordIndices = (
+  groups: number[][],
+  prevCounts: number[],
+  nextCounts: number[],
+): number[] => {
+  const out: number[] = [];
+  for (let g = 0; g < groups.length; g += 1) {
+    const prev = prevCounts[g] ?? 0;
+    const next = nextCounts[g] ?? 0;
+    const group = groups[g];
+    for (let i = prev; i < next && i < group.length; i += 1) {
+      out.push(group[i]);
+    }
+  }
+  return out;
+};
+
+/** Convert a %-space rect into pixel crop args for drawImage. */
+export const rectToCrop = (
+  rect: WordRect,
+  renderW: number,
+  renderH: number,
+): { sx: number; sy: number; sw: number; sh: number } | null => {
+  const sx = (rect.left / 100) * renderW;
+  const sy = (rect.top / 100) * renderH;
+  const sw = (rect.width / 100) * renderW;
+  const sh = (rect.height / 100) * renderH;
+  if (sw <= 0 || sh <= 0) {
+    return null;
+  }
+  return { sx, sy, sw, sh };
+};
+
+/** Caret blink on for this typing progress (matches prior 48-phase parity). */
+export const caretVisibleAt = (t: number): boolean =>
+  t > 0 && t < 1 && Math.floor(t * 48) % 2 === 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack
Stacked on [#1402](https://github.com/tnorlund/Portfolio/pull/1402) (`… → worker → bitmap → #1399`).

Merge order: **#1399 → #1401 → #1402 → this → autoplay**.

## Summary
- Do **not** reset `canvas.width`/`height` every typing tick (was reallocating a ~760×2471 buffer each frame)
- Incremental `drawImage` crops for newly revealed words only
- Prefer `ImageBitmap` for the final receipt source
- Pure helpers in `assembleDraw.ts` with unit tests

## Testing
- [x] assembleDraw + SynthesisPipeline tests
- [x] type-check / ESLint

## Related
Part of the SynthesisPipeline client perf stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

