### PR TITLE
feat(portfolio): throttle SynthesisPipeline autoplay publishes (stack)

### DIFF
--- a/portfolio/components/ui/Figures/SynthesisPipeline/autoplayPublish.test.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/autoplayPublish.test.ts
@@ -1,0 +1,25 @@
+import { shouldPublishAutoplay } from "./autoplayPublish";
+
+test("always publishes on act change", () => {
+  expect(
+    shouldPublishAutoplay(1, 0.01, 0, 0.99, 0, 1, 33, 0.01),
+  ).toEqual({ publishAct: true, publishProgress: true });
+});
+
+test("throttles progress within the interval and delta", () => {
+  expect(
+    shouldPublishAutoplay(0, 0.005, 0, 0, 100, 120, 33, 0.01),
+  ).toEqual({ publishAct: false, publishProgress: false });
+});
+
+test("publishes progress when interval elapses", () => {
+  expect(
+    shouldPublishAutoplay(0, 0.02, 0, 0.01, 100, 140, 33, 0.01),
+  ).toEqual({ publishAct: false, publishProgress: true });
+});
+
+test("publishes progress when delta is large even inside the interval", () => {
+  expect(
+    shouldPublishAutoplay(0, 0.2, 0, 0.05, 100, 110, 33, 0.01),
+  ).toEqual({ publishAct: false, publishProgress: true });
+});

--- a/portfolio/components/ui/Figures/SynthesisPipeline/autoplayPublish.ts
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/autoplayPublish.ts
@@ -1,0 +1,37 @@
+/**
+ * Decide when the autoplay rAF loop should publish React state.
+ * Keeps refs authoritative every frame while limiting reconciles.
+ */
+
+export const AUTOPLAY_PROGRESS_MIN_INTERVAL_MS = 33; // ~30fps UI updates
+export const AUTOPLAY_PROGRESS_MIN_DELTA = 0.01;
+
+export type PublishDecision = {
+  publishAct: boolean;
+  publishProgress: boolean;
+};
+
+/**
+ * `refs` are the latest timeline values; `rendered*` are last values pushed to React.
+ * Always publish act changes. Throttle progress to an interval / minimum delta,
+ * and always publish progress when an act boundary is crossed.
+ */
+export const shouldPublishAutoplay = (
+  nextAct: number,
+  nextProgress: number,
+  renderedAct: number,
+  renderedProgress: number,
+  lastProgressPublishMs: number,
+  nowMs: number,
+  minIntervalMs: number = AUTOPLAY_PROGRESS_MIN_INTERVAL_MS,
+  minDelta: number = AUTOPLAY_PROGRESS_MIN_DELTA,
+): PublishDecision => {
+  const publishAct = nextAct !== renderedAct;
+  if (publishAct) {
+    return { publishAct: true, publishProgress: true };
+  }
+  const delta = Math.abs(nextProgress - renderedProgress);
+  const due =
+    nowMs - lastProgressPublishMs >= minIntervalMs || delta >= minDelta;
+  return { publishAct: false, publishProgress: due && delta > 0 };
+};

--- a/portfolio/components/ui/Figures/SynthesisPipeline/index.tsx
+++ b/portfolio/components/ui/Figures/SynthesisPipeline/index.tsx
@@ -4,6 +4,7 @@ import { ShowcaseLabelFile } from "../AugmentationShowcase/labelGeometry";
 import { GlyphSkeleton } from "./geometry";
 import { ActView } from "./Acts";
 import { useActTransition } from "./actTransition";
+import { shouldPublishAutoplay } from "./autoplayPublish";
 import {
   ACT_COUNT,
   ACT_DWELL_MS,
@@ -103,15 +104,21 @@ const SynthesisPipeline: React.FC = () => {
   const loadedRef = useRef(false);
   const actRef = useRef(0);
   const progRef = useRef(0);
+  // Last values actually published to React — used to throttle setState.
+  const renderedActRef = useRef(0);
+  const renderedProgRef = useRef(0);
+  const lastProgressPublishMsRef = useRef(0);
   const resumeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Mirror render state into refs so the rAF loop can resume from wherever the
   // timeline currently is (after a pause, a jump, or scrolling back in).
   useEffect(() => {
     actRef.current = activeAct;
+    renderedActRef.current = activeAct;
   }, [activeAct]);
   useEffect(() => {
     progRef.current = actProgress;
+    renderedProgRef.current = actProgress;
   }, [actProgress]);
 
   // Load the Sprouts JSON assets once, when the figure is near view.
@@ -155,9 +162,9 @@ const SynthesisPipeline: React.FC = () => {
 
   const playing = inView && !paused && !reducedMotion;
 
-  // Autoplay clock: while playing, advance the active act's progress each
-  // frame, wrapping to the next act. Cancels (and preserves position via refs)
-  // when playing stops — out of view, paused, or reduced motion.
+  // Autoplay clock: advance refs every frame, but only publish React state at
+  // ~30fps (or on act boundaries) so thermal/assemble aren't starved by
+  // reconciles on every rAF tick.
   useEffect(() => {
     if (!playing) {
       return;
@@ -175,8 +182,24 @@ const SynthesisPipeline: React.FC = () => {
       prog = next.actProgress;
       actRef.current = act;
       progRef.current = prog;
-      setActiveAct(act);
-      setActProgress(prog);
+
+      const decision = shouldPublishAutoplay(
+        act,
+        prog,
+        renderedActRef.current,
+        renderedProgRef.current,
+        lastProgressPublishMsRef.current,
+        ts,
+      );
+      if (decision.publishAct) {
+        renderedActRef.current = act;
+        setActiveAct(act);
+      }
+      if (decision.publishProgress) {
+        renderedProgRef.current = prog;
+        lastProgressPublishMsRef.current = ts;
+        setActProgress(prog);
+      }
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
@@ -217,6 +240,8 @@ const SynthesisPipeline: React.FC = () => {
       setActProgress(1); // show the act resolved while paused
       actRef.current = index;
       progRef.current = 1;
+      renderedActRef.current = index;
+      renderedProgRef.current = 1;
       pauseForInteraction();
     },
     [pauseForInteraction],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack
Stacked on [#1403](https://github.com/tnorlund/Portfolio/pull/1403).

**Full merge order (bottom → top):**
1. [#1399](https://github.com/tnorlund/Portfolio/pull/1399) — WASM kernels → `main`
2. [#1401](https://github.com/tnorlund/Portfolio/pull/1401) — ImageBitmap ink cache
3. [#1402](https://github.com/tnorlund/Portfolio/pull/1402) — Web Worker kernels
4. [#1403](https://github.com/tnorlund/Portfolio/pull/1403) — Incremental assemble drawing
5. **This PR** — Autoplay React publish throttle

## Summary
- rAF still advances timeline refs every frame
- `setActProgress` publishes at ~30fps (or when progress jumps ≥0.01)
- Act changes always publish immediately
- Cuts main-thread React reconcile cost during autoplay

## Testing
- [x] `autoplayPublish` unit tests + SynthesisPipeline suite
- [x] type-check / ESLint

## Notes on GitHub stacking
Each PR’s **base branch** is the previous stack tip (not `main`). Merge from the bottom up; GitHub will retarget the next PR’s base as each lands (or retarget manually if needed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a8677f8-7b2e-4621-8909-f3ca8f417a1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

