### PR TITLE
chore: add Cursor cloud-agent environment config and AGENTS.md

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "install": "bash .cursor/install.sh",
+  "start": "source .venv/bin/activate && python --version",
+  "terminals": []
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -4,30 +4,43 @@ set -euo pipefail
 
 # Bootstrap for Cursor cloud-agent VMs (Ubuntu).
 # Mirrors the "repository-tests" install block in .github/workflows/main.yml:
-# Python 3.13 venv with every local package editable-installed, plus the
-# Next.js app's node_modules. scripts/ensure_python_runtime.sh is
-# Homebrew-based (self-hosted Mac runners) and does not work here.
+# Python 3.13 venv with the same editable package set, plus the Next.js app's
+# node_modules. scripts/ensure_python_runtime.sh is Homebrew-based
+# (self-hosted Mac runners) and does not work here.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 PYTHON_VERSION="3.13"
+NODE_VERSION="22"
+
+ensure_uv() {
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+}
 
 # --- Python 3.13 (matches the CI pin) ---
 if command -v "python${PYTHON_VERSION}" >/dev/null 2>&1; then
     PYTHON_BIN="$(command -v "python${PYTHON_VERSION}")"
 else
-    if ! command -v uv >/dev/null 2>&1; then
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        export PATH="$HOME/.local/bin:$PATH"
-    fi
+    ensure_uv
     uv python install "$PYTHON_VERSION"
     PYTHON_BIN="$(uv python find "$PYTHON_VERSION")"
 fi
 "$PYTHON_BIN" --version
 
 if [[ ! -x .venv/bin/python ]]; then
-    "$PYTHON_BIN" -m venv .venv
+    # A distro python3.13 without the python3.13-venv package fails here;
+    # fall back to a uv-managed interpreter, which always bundles venv+pip.
+    if ! "$PYTHON_BIN" -m venv .venv; then
+        echo "$PYTHON_BIN cannot create venvs; falling back to uv" >&2
+        rm -rf .venv
+        ensure_uv
+        uv python install "$PYTHON_VERSION"
+        uv venv --seed --python "$PYTHON_VERSION" .venv
+    fi
 fi
 source .venv/bin/activate
 pip install --upgrade --quiet pip wheel
@@ -48,13 +61,14 @@ pip install black isort
 
 # --- Node 22 (matches CI) + Next.js app dependencies ---
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-if [[ -s "$NVM_DIR/nvm.sh" ]]; then
-    # shellcheck disable=SC1091
-    source "$NVM_DIR/nvm.sh"
-    nvm install 22
-    nvm alias default 22
-    nvm use 22
+if [[ ! -s "$NVM_DIR/nvm.sh" ]]; then
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 fi
+# shellcheck disable=SC1091
+source "$NVM_DIR/nvm.sh"
+nvm install "$NODE_VERSION"
+nvm alias default "$NODE_VERSION"
+nvm use "$NODE_VERSION"
 node --version
 (cd portfolio && npm ci --prefer-offline)
 

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Bootstrap for Cursor cloud-agent VMs (Ubuntu).
+# Mirrors the "repository-tests" install block in .github/workflows/main.yml:
+# Python 3.13 venv with every local package editable-installed, plus the
+# Next.js app's node_modules. scripts/ensure_python_runtime.sh is
+# Homebrew-based (self-hosted Mac runners) and does not work here.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON_VERSION="3.13"
+
+# --- Python 3.13 (matches the CI pin) ---
+if command -v "python${PYTHON_VERSION}" >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v "python${PYTHON_VERSION}")"
+else
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    uv python install "$PYTHON_VERSION"
+    PYTHON_BIN="$(uv python find "$PYTHON_VERSION")"
+fi
+"$PYTHON_BIN" --version
+
+if [[ ! -x .venv/bin/python ]]; then
+    "$PYTHON_BIN" -m venv .venv
+fi
+source .venv/bin/activate
+pip install --upgrade --quiet pip wheel
+pip install -e receipt_dynamo
+pip install --no-deps -e receipt_dynamo_stream
+pip install --no-deps -e receipt_chroma
+pip install --no-deps -e receipt_places
+pip install --no-deps -e receipt_agent
+pip install --no-deps -e receipt_upload
+pip install boto3 chromadb "openai>=2.8.1,<3.0.0" Pillow \
+    pillow-avif-plugin langsmith langgraph \
+    "langchain-core>=0.3.0" "langchain-openai>=0.2.0" httpx \
+    pydantic pydantic-settings structlog requests tenacity \
+    segno python-barcode numpy
+pip install pytest pytest-asyncio pytest-mock pytest-cov pytest-xdist \
+    pytest-timeout pytest-rerunfailures moto responses
+pip install black isort
+
+# --- Node 22 (matches CI) + Next.js app dependencies ---
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "$NVM_DIR/nvm.sh"
+    nvm install 22
+    nvm alias default 22
+    nvm use 22
+fi
+node --version
+(cd portfolio && npm ci --prefer-offline)
+
+echo "Install complete: source .venv/bin/activate for the Python stack."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent Instructions
+
+Full project documentation lives in [CLAUDE.md](CLAUDE.md) — architecture, training/export
+pipelines, the QA-agent evaluation workflow, and PR screenshot conventions. Read it first;
+this file only covers environment mechanics.
+
+## Environment
+
+- Python 3.13 venv at `.venv/` (created by `.cursor/install.sh`) with all local packages
+  editable-installed: `receipt_dynamo`, `receipt_dynamo_stream`, `receipt_chroma`,
+  `receipt_places`, `receipt_agent`, `receipt_upload`. Activate with `source .venv/bin/activate`.
+- Node 22 with `portfolio/node_modules` installed via `npm ci`. The Next.js app lives in
+  `portfolio/` (`npm run dev`, `npm test`, `npm run build`).
+- No AWS credentials are present by default. Unit tests use `moto` and pass offline; skip
+  anything marked integration/e2e or that reaches real AWS, Pulumi, or Chroma Cloud.
+
+## Checks
+
+- Format: `make format` (Black + isort). Lint: `make lint`.
+- Python tests: `pytest <package>/tests` from the repo root with the venv active.
+- Frontend: `cd portfolio && npm test`.
+- CI (`.github/workflows/main.yml`) pins Python 3.13 and Node 22 — match those, not newer.
+
+## Conventions
+
+- Never commit directly to `main`; work on feature branches.
+- Do not run `pulumi` commands; deploys are CI-driven (and a local `pulumi up` can lock the
+  account-wide stack).
+- Don't commit screenshots, logs, or `dev.*` scratch scripts you didn't author.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ this file only covers environment mechanics.
 
 ## Environment
 
-- Python 3.13 venv at `.venv/` (created by `.cursor/install.sh`) with all local packages
-  editable-installed: `receipt_dynamo`, `receipt_dynamo_stream`, `receipt_chroma`,
-  `receipt_places`, `receipt_agent`, `receipt_upload`. Activate with `source .venv/bin/activate`.
+- Python 3.13 venv at `.venv/` (created by `.cursor/install.sh`) with the same editable
+  package set as CI's `repository-tests` job: `receipt_dynamo`, `receipt_dynamo_stream`,
+  `receipt_chroma`, `receipt_places`, `receipt_agent`, `receipt_upload`. Activate with
+  `source .venv/bin/activate`. NOT installed (heavy extras — PySpark, torch, CoreML):
+  `receipt_langsmith`, `receipt_layoutlm`, `receipt_logo`; run
+  `pip install -e "<package>[test]"` yourself before working on those.
 - Node 22 with `portfolio/node_modules` installed via `npm ci`. The Next.js app lives in
   `portfolio/` (`npm run dev`, `npm test`, `npm run build`).
 - No AWS credentials are present by default. Unit tests use `moto` and pass offline; skip


### PR DESCRIPTION
## Summary
- Add `.cursor/environment.json` + `.cursor/install.sh` so Cursor cloud/background agents can provision a working VM: Python 3.13 venv with all six local packages editable-installed (mirrors the `repository-tests` install block in `main.yml`), Node 22 via nvm, and `npm ci` in `portfolio/`.
- Add `AGENTS.md` pointing agents at CLAUDE.md, with cloud-VM guardrails: no AWS creds by default (moto-only unit tests), never run `pulumi`, match CI's Python 3.13 / Node 22 pins, feature branches only.

## Notes
- `scripts/ensure_python_runtime.sh` is Homebrew-based (self-hosted Mac runners) and doesn't work on Ubuntu VMs; the install script falls back to `uv` for Python 3.13.
- No CI or runtime behavior changes — config files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated development-environment setup for Python and Node.js projects.
  * Added virtual environment creation and dependency installation support.
  * Added project guidance covering testing, formatting, CI, branching, and deployment practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->