### PR TITLE
chore: issue templates + stale bot after backlog triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Something broken or incorrect in production/dev
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Use existing P0–P3 labels after filing if the form cannot apply them.
+      options:
+        - P0: Critical (blocks other work)
+        - P1: High (core functionality)
+        - P2: Medium (important, not blocking)
+        - P3: Low (nice to have)
+      default: 2
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - receipt_dynamo / data
+        - receipt_upload / OCR pipeline
+        - receipt_places / merchant
+        - receipt_agent / QA
+        - LayoutLM / CoreML
+        - Swift OCR worker
+        - portfolio frontend
+        - infra / Pulumi
+        - other
+      default: 8
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong, in 1–3 sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro
+      description: Concrete IDs, commands, or steps. Prefer image_id / receipt_id when relevant.
+      placeholder: |
+        image_id: …
+        receipt_id: …
+        env: dev | prod
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,55 @@
+name: Feature / enhancement
+description: New capability or intentional improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0: Critical (blocks other work)
+        - P1: High (core functionality)
+        - P2: Medium (important, not blocking)
+        - P3: Low (nice to have)
+      default: 2
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - receipt_dynamo / data
+        - receipt_upload / OCR pipeline
+        - receipt_places / merchant
+        - receipt_agent / QA
+        - LayoutLM / CoreML
+        - Swift OCR worker
+        - portfolio frontend
+        - infra / Pulumi
+        - other
+      default: 8
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or system pain does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Concrete change. Prefer one deliverable over an epic.
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Done when
+      description: Acceptance criteria / how we know this is finished.
+    validations:
+      required: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale issues
+
+on:
+  schedule:
+    # Mondays 07:30 UTC
+    - cron: "30 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues only — Dependabot / feature PRs are handled elsewhere.
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          # Keep actively prioritized work out of auto-close.
+          exempt-issue-labels: "P0: Critical,P1: High"
+          remove-stale-when-updated: true
+          operations-per-run: 60
+          stale-issue-message: >
+            This issue has had no activity for 90 days. It will be closed in 14
+            days unless there is a comment confirming it is still relevant
+            (and ideally a current repro or acceptance criteria).
+            P0/P1 issues are exempt from this bot.
+          close-issue-message: >
+            Closing as not planned due to sustained inactivity after the stale
+            notice. Reopen with an updated repro or split into a focused issue
+            if this is still needed.
+          close-issue-reason: not_planned


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds bug/feature GitHub issue forms that require priority + component
- Adds a Monday stale workflow (90d stale → 14d close, P0/P1 exempt)
- Complements the manual triage already applied on open issues (11 closed, remaining labeled P0–P3)

## Manual triage already done on `main` (issue metadata, not in this diff)

**Closed (11):**
- `not_planned`: #159, #654, #662, #782, #828, #874, #919, #920
- `completed`: #892 (v3 `skip-coreml-export` tags now set)
- `duplicate` of #879: #1144, #1159

**Kept open (26), all priority-labeled:**
- **P0 (2):** #1050, #1272
- **P1 (9):** #879 (segmentation epic), #993, #1141, #1208, #1264–#1271, #1280
- **P2 (14):** place/render/label/QA follow-ups including #1188 render epic
- **P3 (1):** #1190

## Type of Change

- [x] 📚 Documentation update
- [x] CI/CD Workflows

## Testing

- [x] Manual testing completed (if applicable) — issue closes/labels verified via GraphQL; workflow YAML reviewed against `actions/stale@v9` inputs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df7428b6-4e41-438d-9d0b-8b6b39785680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df7428b6-4e41-438d-9d0b-8b6b39785680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

