### PR TITLE
fix: batch GSI1PK enum writes (#1272) + label-evaluator URN singleton (#1050)

### DIFF
--- a/infra/components/shared_label_evaluator_resources/__init__.py
+++ b/infra/components/shared_label_evaluator_resources/__init__.py
@@ -19,6 +19,10 @@ import pulumi
 import pulumi_aws as aws
 from pulumi import ComponentResource, Output, ResourceOptions
 
+# Process-local singleton so accidental double calls (or dual import paths)
+# cannot RegisterResource the same URN twice in one program run.
+_shared_instance: "SharedLabelEvaluatorResources | None" = None
+
 
 class SharedLabelEvaluatorResources(ComponentResource):
     """
@@ -133,14 +137,31 @@ def create_shared_label_evaluator_resources(
 ) -> SharedLabelEvaluatorResources:
     """Factory function to create shared label evaluator resources.
 
+    Idempotent within a process: a second call returns the same instance
+    instead of registering a duplicate URN (see #1050). Callers in
+    ``infra/__main__.py`` must still invoke this **early** in program
+    evaluation so ``pulumi --target`` does not race a late RegisterResource
+    against an engine-side ``same`` step from state.
+
     Args:
-        opts: Pulumi resource options
+        opts: Pulumi resource options (honored only on first construction)
 
     Returns:
         SharedLabelEvaluatorResources component with batch and viz-cache buckets
     """
+    global _shared_instance
+    if _shared_instance is not None:
+        return _shared_instance
+
     stack = pulumi.get_stack()
-    return SharedLabelEvaluatorResources(
+    _shared_instance = SharedLabelEvaluatorResources(
         f"label-evaluator-{stack}",
         opts=opts,
     )
+    return _shared_instance
+
+
+def _reset_shared_label_evaluator_resources_for_tests() -> None:
+    """Clear the process singleton (unit tests only)."""
+    global _shared_instance
+    _shared_instance = None

--- a/infra/embedding_step_functions/tests/test_embedding_state_handlers.py
+++ b/infra/embedding_step_functions/tests/test_embedding_state_handlers.py
@@ -292,5 +292,5 @@ def test_canceling_batch_keeps_claims_until_provider_is_terminal() -> None:
         "batch-a", "openai-a", "canceling", FakeDynamo()
     )
 
-    assert summary.status == BatchStatus.CANCELING
+    assert summary.status == BatchStatus.CANCELING.value
     assert result["marked_for_retry"] == 0

--- a/infra/embedding_step_functions/unified_embedding/handlers/list_pending.py
+++ b/infra/embedding_step_functions/unified_embedding/handlers/list_pending.py
@@ -3,48 +3,23 @@
 Pure business logic - no Lambda-specific code.
 """
 
+import json
 import os
-from typing import Any, Dict, List
+import tempfile
+from typing import Any, Dict
 
-from receipt_dynamo.constants import BatchType
+import boto3
+from receipt_chroma.embedding.openai.poll import (
+    list_pending_line_embedding_batches,
+    list_pending_word_embedding_batches,
+)
 from receipt_dynamo.data.dynamo_client import DynamoClient
-from receipt_dynamo.entities import BatchSummary
 
 import utils.logging
 
 get_logger = utils.logging.get_logger
 
 logger = get_logger(__name__)
-
-
-def _list_pending_batches(
-    dynamo_client: DynamoClient, batch_type: BatchType
-) -> List[BatchSummary]:
-    """
-    List pending embedding batches from DynamoDB with pagination.
-
-    Args:
-        dynamo_client: DynamoDB client instance
-        batch_type: Type of batches to list (LINE_EMBEDDING or WORD_EMBEDDING)
-
-    Returns:
-        List of pending batch summaries
-    """
-    summaries, lek = dynamo_client.get_batch_summaries_by_status(
-        status="PENDING",
-        batch_type=batch_type,
-        limit=25,
-        last_evaluated_key=None,
-    )
-    while lek:
-        next_summaries, lek = dynamo_client.get_batch_summaries_by_status(
-            status="PENDING",
-            batch_type=batch_type,
-            limit=25,
-            last_evaluated_key=lek,
-        )
-        summaries.extend(next_summaries)
-    return summaries
 
 
 def handle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -80,40 +55,30 @@ def handle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     )
 
     try:
-        # Initialize DynamoDB client
         dynamo_client = DynamoClient(os.environ.get("DYNAMODB_TABLE_NAME"))
 
-        # Get pending batches from DynamoDB
+        # Keep every provider-live status visible (PENDING through CANCELING).
         if batch_type == "word":
-            pending_batches = _list_pending_batches(
-                dynamo_client, BatchType.WORD_EMBEDDING
-            )
+            pending_batches = list_pending_word_embedding_batches(dynamo_client)
             logger.info(
                 "Found pending word embedding batches",
                 count=len(pending_batches),
             )
         else:
-            pending_batches = _list_pending_batches(
-                dynamo_client, BatchType.LINE_EMBEDDING
-            )
+            pending_batches = list_pending_line_embedding_batches(dynamo_client)
             logger.info(
                 "Found pending line embedding batches",
                 count=len(pending_batches),
             )
 
-        # Format response for Step Function
-        # Create batch_indices array for Map state
         batch_indices = list(range(len(pending_batches)))
 
-        # Check if we need to use S3 (if batches array is large)
-        # Step Functions has a 256KB limit, so we'll use S3 if batches > 100KB
-        import json
-
+        # Step Functions has a 256KB limit; spill to S3 above 100KB.
         batches_payload = json.dumps(
             [batch.__dict__ for batch in pending_batches]
         )
         batches_size = len(batches_payload.encode("utf-8"))
-        use_s3 = batches_size > 100 * 1024  # 100KB threshold
+        use_s3 = batches_size > 100 * 1024
 
         response = {
             "total_batches": len(pending_batches),
@@ -122,11 +87,6 @@ def handle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         }
 
         if use_s3:
-            # Upload batches to S3 manifest
-            import tempfile
-
-            import boto3
-
             bucket = os.environ.get("CHROMADB_BUCKET")
             if not bucket:
                 raise ValueError(
@@ -134,8 +94,6 @@ def handle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 )
 
             manifest_s3_key = f"manifests/{execution_id}/batches.json"
-
-            # Serialize batches to JSON
             batches_data = [
                 {
                     "batch_id": batch.batch_id,
@@ -168,19 +126,18 @@ def handle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             finally:
                 try:
                     os.unlink(tmp_file_path)
-                except Exception:
+                except OSError:
                     pass
 
             response.update(
                 {
-                    "pending_batches": None,  # Not included when using S3
+                    "pending_batches": None,
                     "manifest_s3_key": manifest_s3_key,
                     "manifest_s3_bucket": bucket,
                     "use_s3": True,
                 }
             )
         else:
-            # Include batches inline
             response.update(
                 {
                     "pending_batches": [

--- a/infra/tests/test_shared_label_evaluator_singleton.py
+++ b/infra/tests/test_shared_label_evaluator_singleton.py
@@ -1,0 +1,41 @@
+"""Factory singleton for shared label-evaluator resources (#1050)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    from components.shared_label_evaluator_resources import (
+        _reset_shared_label_evaluator_resources_for_tests,
+    )
+
+    _reset_shared_label_evaluator_resources_for_tests()
+    yield
+    _reset_shared_label_evaluator_resources_for_tests()
+
+
+def test_create_shared_label_evaluator_resources_is_idempotent(monkeypatch):
+    """A second factory call must reuse the instance, not re-register the URN."""
+    import components.shared_label_evaluator_resources as mod
+
+    constructed: list[object] = []
+
+    class FakeShared:
+        def __init__(self, name, *, opts=None):
+            self.name = name
+            self.opts = opts
+            constructed.append(self)
+
+    monkeypatch.setattr(mod, "SharedLabelEvaluatorResources", FakeShared)
+    monkeypatch.setattr(
+        mod.pulumi, "get_stack", lambda: "dev"
+    )
+
+    first = mod.create_shared_label_evaluator_resources()
+    second = mod.create_shared_label_evaluator_resources(opts=MagicMock())
+
+    assert first is second
+    assert len(constructed) == 1
+    assert first.name == "label-evaluator-dev"

--- a/receipt_chroma/receipt_chroma/embedding/openai/batch_status.py
+++ b/receipt_chroma/receipt_chroma/embedding/openai/batch_status.py
@@ -23,28 +23,34 @@ from receipt_dynamo.entities import BatchSummary
 logger = logging.getLogger(__name__)
 
 
-def map_openai_to_dynamo_status(openai_status: str) -> BatchStatus:
+def map_openai_to_dynamo_status(openai_status: str) -> str:
     """
-    Map OpenAI batch status to DynamoDB BatchStatus enum.
+    Map OpenAI batch status to the DynamoDB BatchStatus string value.
+
+    Returns the enum ``.value`` (e.g. ``\"IN_PROGRESS\"``), never the member
+    itself. Assigning a ``BatchStatus`` member onto ``BatchSummary.status``
+    and persisting without re-normalization embeds the enum repr into
+    ``GSI1PK`` (``STATUS#BatchStatus.IN_PROGRESS``), which
+    ``get_batch_summaries_by_status`` cannot query.
 
     Args:
         openai_status: Status string from OpenAI API
 
     Returns:
-        Corresponding BatchStatus enum value
+        Corresponding BatchStatus ``.value`` string
 
     Raises:
         ValueError: If status is unknown
     """
     mapping = {
-        "validating": BatchStatus.VALIDATING,
-        "in_progress": BatchStatus.IN_PROGRESS,
-        "finalizing": BatchStatus.FINALIZING,
-        "completed": BatchStatus.COMPLETED,
-        "failed": BatchStatus.FAILED,
-        "expired": BatchStatus.EXPIRED,
-        "canceling": BatchStatus.CANCELING,
-        "cancelled": BatchStatus.CANCELLED,
+        "validating": BatchStatus.VALIDATING.value,
+        "in_progress": BatchStatus.IN_PROGRESS.value,
+        "finalizing": BatchStatus.FINALIZING.value,
+        "completed": BatchStatus.COMPLETED.value,
+        "failed": BatchStatus.FAILED.value,
+        "expired": BatchStatus.EXPIRED.value,
+        "canceling": BatchStatus.CANCELING.value,
+        "cancelled": BatchStatus.CANCELLED.value,
     }
 
     if openai_status not in mapping:
@@ -268,7 +274,7 @@ def handle_failed_status(
 
     # Update batch summary in DynamoDB
     batch_summary = dynamo_client.get_batch_summary(batch_id)
-    batch_summary.status = BatchStatus.FAILED
+    batch_summary.status = BatchStatus.FAILED.value
     dynamo_client.update_batch_summary(batch_summary)
 
     # Mark all failed items for retry based on batch type
@@ -341,7 +347,7 @@ def handle_expired_status(
 
     # Update batch summary
     batch_summary = dynamo_client.get_batch_summary(batch_id)
-    batch_summary.status = BatchStatus.EXPIRED
+    batch_summary.status = BatchStatus.EXPIRED.value
     dynamo_client.update_batch_summary(batch_summary)
 
     # An expired provider batch is terminal.  Requeue both the failed IDs and

--- a/receipt_chroma/receipt_chroma/embedding/openai/poll.py
+++ b/receipt_chroma/receipt_chroma/embedding/openai/poll.py
@@ -10,11 +10,51 @@ from typing import List
 
 from openai import OpenAI
 
-from receipt_dynamo.constants import BatchType
+from receipt_dynamo.constants import BatchStatus, BatchType
 from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.entities import BatchSummary
 
 logger = logging.getLogger(__name__)
+
+# Provider-live statuses that ingest must keep polling. Writing the OpenAI
+# status onto BatchSummary means a batch leaves PENDING after the first poll;
+# querying only PENDING strands it until a manual reset.
+ACTIVE_BATCH_STATUSES = (
+    BatchStatus.PENDING,
+    BatchStatus.VALIDATING,
+    BatchStatus.IN_PROGRESS,
+    BatchStatus.FINALIZING,
+    BatchStatus.CANCELING,
+)
+
+
+def _list_active_batches(
+    dynamo_client: DynamoClient, batch_type: BatchType
+) -> List[BatchSummary]:
+    """List every provider-live embedding batch with pagination."""
+    summaries: dict[str, BatchSummary] = {}
+    for status in ACTIVE_BATCH_STATUSES:
+        page, lek = dynamo_client.get_batch_summaries_by_status(
+            status=status,
+            batch_type=batch_type,
+            limit=25,
+            last_evaluated_key=None,
+        )
+        for summary in page:
+            summaries[summary.batch_id] = summary
+        while lek:
+            page, lek = dynamo_client.get_batch_summaries_by_status(
+                status=status,
+                batch_type=batch_type,
+                limit=25,
+                last_evaluated_key=lek,
+            )
+            for summary in page:
+                summaries[summary.batch_id] = summary
+    return sorted(
+        summaries.values(),
+        key=lambda summary: (summary.submitted_at, summary.batch_id),
+    )
 
 
 def get_openai_batch_status(
@@ -110,55 +150,35 @@ def list_pending_line_embedding_batches(
     dynamo_client: DynamoClient,
 ) -> List[BatchSummary]:
     """
-    List line embedding batches that are pending processing.
+    List line embedding batches that still need polling.
+
+    Includes every provider-live status (PENDING through CANCELING), not just
+    PENDING. The first poll writes the OpenAI status onto the summary, so a
+    PENDING-only query would strand in-flight batches across ingest runs.
 
     Args:
         dynamo_client: DynamoDB client instance
 
     Returns:
-        List of pending batch identifiers
+        Deduplicated active batch summaries, oldest first.
     """
-    summaries, lek = dynamo_client.get_batch_summaries_by_status(
-        status="PENDING",
-        batch_type=BatchType.LINE_EMBEDDING,
-        limit=25,
-        last_evaluated_key=None,
-    )
-    while lek:
-        next_summaries, lek = dynamo_client.get_batch_summaries_by_status(
-            status="PENDING",
-            batch_type=BatchType.LINE_EMBEDDING,
-            limit=25,
-            last_evaluated_key=lek,
-        )
-        summaries.extend(next_summaries)
-    return summaries  # type: ignore[no-any-return]
+    return _list_active_batches(dynamo_client, BatchType.LINE_EMBEDDING)
 
 
 def list_pending_word_embedding_batches(
     dynamo_client: DynamoClient,
 ) -> List[BatchSummary]:
     """
-    List word embedding batches that are pending processing.
+    List word embedding batches that still need polling.
+
+    Includes every provider-live status (PENDING through CANCELING), not just
+    PENDING. The first poll writes the OpenAI status onto the summary, so a
+    PENDING-only query would strand in-flight batches across ingest runs.
 
     Args:
         dynamo_client: DynamoDB client instance
 
     Returns:
-        List of pending batch identifiers
+        Deduplicated active batch summaries, oldest first.
     """
-    summaries, lek = dynamo_client.get_batch_summaries_by_status(
-        status="PENDING",
-        batch_type=BatchType.WORD_EMBEDDING,
-        limit=25,
-        last_evaluated_key=None,
-    )
-    while lek:
-        next_summaries, lek = dynamo_client.get_batch_summaries_by_status(
-            status="PENDING",
-            batch_type=BatchType.WORD_EMBEDDING,
-            limit=25,
-            last_evaluated_key=lek,
-        )
-        summaries.extend(next_summaries)
-    return summaries  # type: ignore[no-any-return]
+    return _list_active_batches(dynamo_client, BatchType.WORD_EMBEDDING)

--- a/receipt_chroma/tests/unit/test_openai_batch_status.py
+++ b/receipt_chroma/tests/unit/test_openai_batch_status.py
@@ -1,0 +1,132 @@
+"""Unit tests for OpenAI batch status → DynamoDB write shape (#1272)."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from receipt_chroma.embedding.openai.batch_status import (
+    handle_cancelled_status,
+    handle_failed_status,
+    handle_in_progress_status,
+    map_openai_to_dynamo_status,
+)
+from receipt_chroma.embedding.openai.poll import (
+    ACTIVE_BATCH_STATUSES,
+    list_pending_line_embedding_batches,
+    list_pending_word_embedding_batches,
+)
+from receipt_dynamo.constants import BatchStatus, BatchType
+from receipt_dynamo.entities import BatchSummary
+
+
+def _summary(status: str = BatchStatus.PENDING.value) -> BatchSummary:
+    return BatchSummary(
+        batch_id="batch-a",
+        batch_type=BatchType.WORD_EMBEDDING.value,
+        openai_batch_id="openai-a",
+        submitted_at=datetime.now(timezone.utc),
+        status=status,
+        result_file_id="",
+        receipt_refs=[("image-a", 1)],
+    )
+
+
+class _CapturingDynamo:
+    def __init__(self, summary: BatchSummary):
+        self.summary = summary
+        self.updated: list[BatchSummary] = []
+
+    def get_batch_summary(self, batch_id: str) -> BatchSummary:
+        assert batch_id == "batch-a"
+        return self.summary
+
+    def update_batch_summary(self, updated: BatchSummary) -> None:
+        self.updated.append(updated)
+
+
+def test_map_openai_to_dynamo_status_returns_string_values() -> None:
+    assert map_openai_to_dynamo_status("in_progress") == "IN_PROGRESS"
+    assert map_openai_to_dynamo_status("validating") == "VALIDATING"
+    assert isinstance(map_openai_to_dynamo_status("finalizing"), str)
+
+
+def test_handle_in_progress_persists_string_status_and_gsi() -> None:
+    summary = _summary()
+    dynamo = _CapturingDynamo(summary)
+
+    result = handle_in_progress_status(
+        "batch-a", "openai-a", "in_progress", dynamo
+    )
+
+    assert result["action"] == "wait"
+    assert summary.status == BatchStatus.IN_PROGRESS.value
+    assert dynamo.updated == [summary]
+    item = summary.to_item()
+    assert item["GSI1PK"] == {"S": "STATUS#IN_PROGRESS"}
+    assert item["status"] == {"S": "IN_PROGRESS"}
+
+
+def test_handle_failed_persists_string_status() -> None:
+    summary = _summary()
+
+    class FakeDynamo(_CapturingDynamo):
+        def list_receipt_words_from_receipt(self, _image_id, _receipt_id):
+            return []
+
+        def update_receipt_words(self, _words):
+            raise AssertionError("no pending words to update")
+
+    dynamo = FakeDynamo(summary)
+
+    class _FakeOpenAI:
+        class batches:
+            @staticmethod
+            def retrieve(_batch_id):
+                return SimpleNamespace(error_file_id=None, status="failed")
+
+    result = handle_failed_status(
+        "batch-a", "openai-a", dynamo, _FakeOpenAI()
+    )
+
+    assert result["status"] == "failed"
+    assert summary.status == BatchStatus.FAILED.value
+    assert summary.to_item()["GSI1PK"] == {"S": "STATUS#FAILED"}
+
+
+def test_handle_cancelled_persists_string_canceling() -> None:
+    summary = _summary(status=BatchStatus.IN_PROGRESS.value)
+    dynamo = _CapturingDynamo(summary)
+
+    result = handle_cancelled_status(
+        "batch-a", "openai-a", "canceling", dynamo
+    )
+
+    assert result["marked_for_retry"] == 0
+    assert summary.status == BatchStatus.CANCELING.value
+    assert summary.to_item()["GSI1PK"] == {"S": "STATUS#CANCELING"}
+
+
+def test_list_pending_batches_covers_provider_active_statuses() -> None:
+    now = datetime.now(timezone.utc)
+    summaries = {
+        status: [
+            SimpleNamespace(
+                batch_id=status.value,
+                submitted_at=now,
+            )
+        ]
+        for status in ACTIVE_BATCH_STATUSES
+    }
+
+    class FakeDynamo:
+        def get_batch_summaries_by_status(
+            self, *, status, batch_type, limit, last_evaluated_key
+        ):
+            del batch_type, limit, last_evaluated_key
+            return summaries[status], None
+
+    found_line = list_pending_line_embedding_batches(FakeDynamo())
+    found_word = list_pending_word_embedding_batches(FakeDynamo())
+
+    expected = {status.value for status in ACTIVE_BATCH_STATUSES}
+    assert {s.batch_id for s in found_line} == expected
+    assert {s.batch_id for s in found_word} == expected

--- a/receipt_dynamo/receipt_dynamo/entities/batch_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/batch_summary.py
@@ -96,6 +96,13 @@ class BatchSummary:
         return self.submitted_at
 
     def to_item(self) -> dict[str, Any]:
+        # Re-normalize on write. Post-init assignment of a BatchStatus member
+        # (e.g. poll handlers setting ``status = BatchStatus.IN_PROGRESS``)
+        # bypasses ``__post_init__``, and ``f"STATUS#{enum}"`` then embeds the
+        # enum repr (``STATUS#BatchStatus.IN_PROGRESS``) into GSI1PK, stranding
+        # the batch from ``get_batch_summaries_by_status``.
+        self.status = normalize_enum(self.status, BatchStatus)
+        self.batch_type = normalize_enum(self.batch_type, BatchType)
         return {
             **self.key,
             **self.gsi1_key(),

--- a/receipt_dynamo/tests/unit/test_batch_summary.py
+++ b/receipt_dynamo/tests/unit/test_batch_summary.py
@@ -202,6 +202,27 @@ def test_batch_summary_invalid_dynamodb_format():
         item_to_batch_summary(item)
 
 
+@pytest.mark.unit
+def test_batch_summary_to_item_normalizes_post_init_enum_assignment(
+    example_batch_summary,
+):
+    """Post-init enum assignment must not corrupt GSI1PK on write (#1272)."""
+    example_batch_summary.status = BatchStatus.IN_PROGRESS
+    example_batch_summary.batch_type = BatchType.WORD_EMBEDDING
+
+    # Without to_item re-normalization, f-strings embed the enum repr.
+    assert f"STATUS#{example_batch_summary.status}" == (
+        "STATUS#BatchStatus.IN_PROGRESS"
+    )
+
+    item = example_batch_summary.to_item()
+    assert item["GSI1PK"] == {"S": "STATUS#IN_PROGRESS"}
+    assert item["status"] == {"S": "IN_PROGRESS"}
+    assert item["batch_type"] == {"S": "WORD_EMBEDDING"}
+    assert example_batch_summary.status == BatchStatus.IN_PROGRESS.value
+    assert item["GSI1SK"]["S"].startswith("BATCH_TYPE#WORD_EMBEDDING#")
+
+
 # === EQUALITY, HASHING, STR, ITER ===
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **#1272**: Stop writing `STATUS#BatchStatus.IN_PROGRESS` into `GSI1PK` during embedding batch polls; re-normalize enums in `BatchSummary.to_item` and list all provider-active statuses (not just PENDING).
- **#1050**: Make `create_shared_label_evaluator_resources()` process-idempotent so a second call cannot re-register the same URN (early registration from #1039 kept).

## Changes

### #1272 Batch GSI / listing
- `map_openai_to_dynamo_status` returns `.value` strings; failed/expired handlers assign `.value`
- `BatchSummary.to_item` re-runs `normalize_enum` (same pattern as `OCRJob`)
- `receipt_chroma` + unified `list_pending` query PENDING/VALIDATING/IN_PROGRESS/FINALIZING/CANCELING

### #1050 Label evaluator URN
- Factory singleton + unit test; `__main__.py` early wire-up unchanged

## Testing

- [x] Unit tests pass locally (`pytest`)
  - `receipt_dynamo/tests/unit/test_batch_summary.py`
  - `receipt_chroma/tests/unit/test_openai_batch_status.py` (new)
  - `infra/embedding_step_functions/tests/test_embedding_state_handlers.py`
  - `infra/tests/test_shared_label_evaluator_singleton.py` (new)

## Notes

Existing stuck summaries with malformed `GSI1PK` still need a one-time reset (as in the original incident recovery via `scripts/set_batch_summaries_pending.py`). This PR prevents new corruption.

Fixes #1272
Fixes #1050

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df7428b6-4e41-438d-9d0b-8b6b39785680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df7428b6-4e41-438d-9d0b-8b6b39785680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

