### PR TITLE
feat(line-items): constrain decode to the printed total

### DIFF
--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -4900,6 +4900,18 @@ def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
     return evaluate_items_zone(words, summary, set(line_ids))
 
 
+def _reconcile_stored_items(items: list[dict], summary: Optional[dict]):
+    """Discount-aware sum for stored rows; same helper as ingest.
+
+    Deferred import matches ``_evaluate_items_zone``: this module loads
+    in tests with a stub ``mcp`` package before upload extras are
+    guaranteed at import time.
+    """
+    from receipt_upload.line_items.geometry import reconcile_extracted_items
+
+    return reconcile_extracted_items(items, summary)
+
+
 async def get_receipt_line_items_impl(
     dynamo_client, image_id: str, receipt_id: int
 ) -> dict:
@@ -4947,18 +4959,29 @@ async def get_receipt_line_items_impl(
             }
             for li in line_items
         ]
-        # Discounts excluded from the sum, matching reconcile()'s callers
-        # (the stream stage and repair_item_sections.evaluate).
-        items_sum = round(
-            sum(float(li.price) for li in line_items if not li.is_discount),
-            2,
-        )
+        priced = [
+            {
+                "price": float(li.price),
+                "is_discount": bool(li.is_discount),
+            }
+            for li in line_items
+        ]
 
-        summary = None
+        figures = None
         baseline = None
+        summary = None
         if record is not None:
             figures, baseline = _summary_baseline(record)
             summary = {**figures, "merchant_name": record.merchant_name}
+        recon = _reconcile_stored_items(priced, figures)
+        items_sum = recon.item_sum
+        if items_sum is None:
+            items_sum = round(
+                sum(p["price"] for p in priced if not p["is_discount"]),
+                2,
+            )
+        if recon.baseline is not None:
+            baseline = recon.baseline
         delta = (
             round(items_sum - baseline, 2) if baseline is not None else None
         )
@@ -5283,13 +5306,17 @@ async def list_reconciliation_worklist_impl(
                     {
                         "merchant": None,
                         "items": 0,
-                        "items_sum": 0.0,
+                        "priced": [],
                         "statuses": set(),
                     },
                 )
                 bucket["items"] += 1
-                if not li.is_discount:
-                    bucket["items_sum"] += float(li.price)
+                bucket["priced"].append(
+                    {
+                        "price": float(li.price),
+                        "is_discount": bool(li.is_discount),
+                    }
+                )
                 if li.merchant_name and not bucket["merchant"]:
                     bucket["merchant"] = li.merchant_name
                 if li.reconciliation_status:
@@ -5319,23 +5346,36 @@ async def list_reconciliation_worklist_impl(
                     "receipt_id": rid,
                     "merchant": bucket["merchant"],
                     "items": bucket["items"],
-                    "items_sum": round(bucket["items_sum"], 2),
+                    "priced": bucket["priced"],
                 }
             )
 
         for i, cand in enumerate(candidates):
+            priced = cand.pop("priced")
+            excluded_sum = round(
+                sum(p["price"] for p in priced if not p["is_discount"]),
+                2,
+            )
+            figures = None
             baseline = None
             if i < max_summary_fetches:
                 try:
                     record = dynamo_client.get_receipt_summary(
                         cand["image_id"], cand["receipt_id"]
                     )
-                    _, baseline = _summary_baseline(record)
+                    figures, baseline = _summary_baseline(record)
                 except EntityNotFoundError:
-                    baseline = None
+                    figures, baseline = None, None
+            recon = _reconcile_stored_items(priced, figures)
+            items_sum = (
+                recon.item_sum if recon.item_sum is not None else excluded_sum
+            )
+            if recon.baseline is not None:
+                baseline = recon.baseline
+            cand["items_sum"] = items_sum
             cand["subtotal"] = baseline
             cand["delta"] = (
-                round(cand["items_sum"] - baseline, 2)
+                round(items_sum - baseline, 2)
                 if baseline is not None
                 else None
             )

--- a/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
+++ b/infra/mcp_server_lambda/lambdas/receipt_mcp_server_server.py
@@ -4892,28 +4892,12 @@ def _summary_baseline(record) -> tuple[dict, Optional[float]]:
 def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
     """Run the real extractor over a line set and reconcile.
 
-    Discounts are excluded from the sum, matching the stream stage and
-    scripts/repair_item_sections.evaluate.
+    Uses ``evaluate_items_zone`` so discount-inclusion and unnamed-band
+    drops stay in lockstep with ingest.
     """
-    from receipt_upload.line_items.geometry import extract_items, reconcile
+    from receipt_upload.line_items.geometry import evaluate_items_zone
 
-    items, collapsed = extract_items(words, set(line_ids))
-    status, items_sum, baseline = reconcile(
-        [x for x in items if not x["is_discount"]], summary
-    )
-    delta = (
-        round(items_sum - baseline, 2)
-        if items_sum is not None and baseline is not None
-        else None
-    )
-    return {
-        "status": status,
-        "items_sum": items_sum,
-        "baseline": baseline,
-        "delta": delta,
-        "n_items": len(items),
-        "collapsed_banding": collapsed,
-    }
+    return evaluate_items_zone(words, summary, set(line_ids))
 
 
 async def get_receipt_line_items_impl(

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -268,7 +268,9 @@ def update_receipt_line_items(
 
     line_ids = {int(x) for x in (items_section.line_ids or [])}
 
-    items, collapsed = extract_items(word_dicts, line_ids, summary=summary_dict)
+    items, collapsed = extract_items(
+        word_dicts, line_ids, summary=summary_dict
+    )
 
     recon = reconcile_extracted_items(items, summary_dict)
     status = recon.status
@@ -277,7 +279,9 @@ def update_receipt_line_items(
     entities = []
     for idx, it in enumerate(items):
         name = it.get("name") or ""
-        quality = "low" if it.get("name_quality") == "low" or not name else "ok"
+        quality = (
+            "low" if it.get("name_quality") == "low" or not name else "ok"
+        )
         entities.append(
             ReceiptLineItem(
                 receipt_id=receipt_id,
@@ -540,7 +544,9 @@ def _maybe_extend_items_section(
     """Persist a reconciliation-verified adjacent-row ITEMS extension."""
 
     try:
-        rows = dynamo_client.get_receipt_rows_from_receipt(image_id, receipt_id)
+        rows = dynamo_client.get_receipt_rows_from_receipt(
+            image_id, receipt_id
+        )
     except EntityNotFoundError:
         rows = []
     proposal = propose_items_boundary_extension(
@@ -873,7 +879,8 @@ def _maybe_trigger_line_item_refine(
         # receipt_dynamo's `assert_valid_uuid` (its regex accepts
         # version 4 or 5 with the RFC-4122 variant).
         figures = ":".join(
-            _claim_figure(refine_summary[key]) for key in REFINE_SUMMARY_FIGURES
+            _claim_figure(refine_summary[key])
+            for key in REFINE_SUMMARY_FIGURES
         )
         job_id = str(
             uuid.uuid5(

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -153,7 +153,7 @@ from receipt_upload.line_items.geometry import (
     extract_items,
     items_boundary_extension_guard,
     propose_items_boundary_extension,
-    reconcile_detailed,
+    reconcile_extracted_items,
 )
 from receipt_upload.line_items.provenance import (
     is_worker_extractor_version,
@@ -268,22 +268,16 @@ def update_receipt_line_items(
 
     line_ids = {int(x) for x in (items_section.line_ids or [])}
 
-    items, collapsed = extract_items(
-        word_dicts, line_ids, summary=summary_dict
-    )
+    items, collapsed = extract_items(word_dicts, line_ids, summary=summary_dict)
 
-    recon = reconcile_detailed(
-        [x for x in items if not x.get("is_discount")], summary_dict
-    )
+    recon = reconcile_extracted_items(items, summary_dict)
     status = recon.status
 
     now = datetime.now(timezone.utc)
     entities = []
     for idx, it in enumerate(items):
         name = it.get("name") or ""
-        quality = (
-            "low" if it.get("name_quality") == "low" or not name else "ok"
-        )
+        quality = "low" if it.get("name_quality") == "low" or not name else "ok"
         entities.append(
             ReceiptLineItem(
                 receipt_id=receipt_id,
@@ -463,10 +457,7 @@ def _reconcile_with_worker_rows(
 
     worker_rows = sorted(worker_rows, key=lambda row: row.item_index)
     worker_items = [_row_to_item(row) for row in worker_rows]
-    worker_recon = reconcile_detailed(
-        [item for item in worker_items if not item["is_discount"]],
-        summary_dict,
-    )
+    worker_recon = reconcile_extracted_items(worker_items, summary_dict)
 
     before = {"status": recon.status, "delta": _delta(recon)}
     after = {"status": worker_recon.status, "delta": _delta(worker_recon)}
@@ -549,9 +540,7 @@ def _maybe_extend_items_section(
     """Persist a reconciliation-verified adjacent-row ITEMS extension."""
 
     try:
-        rows = dynamo_client.get_receipt_rows_from_receipt(
-            image_id, receipt_id
-        )
+        rows = dynamo_client.get_receipt_rows_from_receipt(image_id, receipt_id)
     except EntityNotFoundError:
         rows = []
     proposal = propose_items_boundary_extension(
@@ -884,8 +873,7 @@ def _maybe_trigger_line_item_refine(
         # receipt_dynamo's `assert_valid_uuid` (its regex accepts
         # version 4 or 5 with the RFC-4122 variant).
         figures = ":".join(
-            _claim_figure(refine_summary[key])
-            for key in REFINE_SUMMARY_FIGURES
+            _claim_figure(refine_summary[key]) for key in REFINE_SUMMARY_FIGURES
         )
         job_id = str(
             uuid.uuid5(

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from itertools import combinations
 from typing import Any, Optional
 
 from receipt_dynamo.amounts import (
@@ -939,7 +940,7 @@ def extract_items(
         load_default_priors(),
         summary=summary,
     )
-    return items, False
+    return constrain_items_to_baseline(items, summary), False
 
 
 def _extract_items_banded(
@@ -1371,6 +1372,114 @@ def is_proven(
 # deliberately absent: an extension cannot be arithmetic-verified when
 # either side has no comparable baseline.
 _BOUNDARY_RECON_RANK = {"match": 0, "near": 1, "mismatch": 2}
+_MAX_CONSTRAINT_DROPS = 3
+
+
+def _priced_for_reconcile(
+    items: list[dict], include_discounts: bool
+) -> list[dict]:
+    """Items that participate in the printed-total sum."""
+
+    if include_discounts:
+        return list(items)
+    return [item for item in items if not item.get("is_discount")]
+
+
+def _recon_eval(result: ReconcileResult) -> dict[str, Any]:
+    """Shape ``items_boundary_extension_guard`` consumes."""
+
+    delta = (
+        round(result.item_sum - result.baseline, 2)
+        if result.item_sum is not None and result.baseline is not None
+        else None
+    )
+    return {"status": result.status, "delta": delta}
+
+
+def reconcile_extracted_items(
+    items: list[dict], summary: Optional[dict]
+) -> ReconcileResult:
+    """Reconcile decoded items against the printed baseline.
+
+    The historical sum skipped ``is_discount`` rows, which over-counts
+    BOGO / void lines that already sit in ITEMS (the discount is the
+    arithmetic). Including discounts is accepted only when it strictly
+    shrinks ``|delta|`` and improves status — the same guard as an
+    ITEMS-boundary repair. A receipt that already matches without
+    discounts is left alone.
+    """
+
+    excluded = reconcile_detailed(_priced_for_reconcile(items, False), summary)
+    if excluded.status == "match" or summary is None:
+        return excluded
+    included = reconcile_detailed(_priced_for_reconcile(items, True), summary)
+    if included.item_sum == excluded.item_sum:
+        return excluded
+    verified, _ = items_boundary_extension_guard(
+        _recon_eval(excluded), _recon_eval(included)
+    )
+    return included if verified else excluded
+
+
+def constrain_items_to_baseline(
+    items: list[dict], summary: Optional[dict]
+) -> list[dict]:
+    """Drop priced bands iff the printed total then reconciles better.
+
+    No merchant vocabulary: unnamed non-discount bands are candidates
+    (a named product coincidentally priced at the gap must survive), and
+    a drop ships only when ``items_boundary_extension_guard`` accepts
+    it. Discounts are never dropped; ``reconcile_extracted_items``
+    decides whether they count. Already-matching receipts are untouched.
+    """
+
+    if not items or summary is None:
+        return items
+    baseline = reconcile_extracted_items(items, summary)
+    if baseline.status == "match":
+        return items
+
+    before = _recon_eval(baseline)
+    winners: list[tuple] = []
+
+    def _consider(drop: tuple[int, ...]) -> None:
+        remaining = [item for i, item in enumerate(items) if i not in drop]
+        if not remaining:
+            return
+        after = reconcile_extracted_items(remaining, summary)
+        verified, _ = items_boundary_extension_guard(before, _recon_eval(after))
+        if not verified:
+            return
+        winners.append(
+            (
+                _BOUNDARY_RECON_RANK.get(after.status, 9),
+                (
+                    abs(after.item_sum - after.baseline)
+                    if after.item_sum is not None and after.baseline is not None
+                    else 99.0
+                ),
+                len(drop),
+                # Prefer dropping later bands (totals sit below items).
+                -max(drop) if drop else 0,
+                drop,
+                after,
+            )
+        )
+
+    droppable = [
+        i
+        for i, item in enumerate(items)
+        if not item.get("is_discount")
+        and not _name_is_real(str(item.get("name") or ""))
+    ]
+    max_k = min(_MAX_CONSTRAINT_DROPS, len(droppable))
+    for k in range(1, max_k + 1):
+        for combo in combinations(droppable, k):
+            _consider(combo)
+    if not winners:
+        return items
+    winners.sort()
+    return [item for i, item in enumerate(items) if i not in winners[0][4]]
 
 
 def evaluate_items_zone(
@@ -1379,14 +1488,13 @@ def evaluate_items_zone(
     """Decode and reconcile one proposed ITEMS zone.
 
     This is shared by the MCP repair tool and the automatic ingest repair so
-    the verifier cannot drift.  Discounts are excluded from the arithmetic,
-    matching every canonical line-item writer.
+    the verifier cannot drift.  The printed total is a constraint: discount
+    lines in ITEMS count when they close the delta, and extra priced bands
+    drop when dropping them improves reconciliation.
     """
 
     items, collapsed = extract_items(words, set(line_ids), summary=summary)
-    result = reconcile_detailed(
-        [item for item in items if not item.get("is_discount")], summary
-    )
+    result = reconcile_extracted_items(items, summary)
     delta = (
         round(result.item_sum - result.baseline, 2)
         if result.item_sum is not None and result.baseline is not None
@@ -1641,9 +1749,7 @@ def propose_items_boundary_extension(
                 for candidate in candidate_rows
                 for line_id in candidate["line_ids"]
             }
-            evaluation = evaluate_items_zone(
-                words, summary, candidate_line_ids
-            )
+            evaluation = evaluate_items_zone(words, summary, candidate_line_ids)
             if evaluation.get("delta") is not None and abs(
                 evaluation["delta"]
             ) < abs(current_evaluation["delta"]):
@@ -1705,6 +1811,7 @@ __all__ = [
     "accept_quantity_pair",
     "band_words",
     "estimate_skew",
+    "constrain_items_to_baseline",
     "evaluate_items_zone",
     "extract_items",
     "implied_unit_price",
@@ -1718,5 +1825,6 @@ __all__ = [
     "quantity_candidates",
     "reconcile",
     "reconcile_detailed",
+    "reconcile_extracted_items",
     "strip_tax_flag",
 ]

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -1373,6 +1373,11 @@ def is_proven(
 # either side has no comparable baseline.
 _BOUNDARY_RECON_RANK = {"match": 0, "near": 1, "mismatch": 2}
 _MAX_CONSTRAINT_DROPS = 3
+# Cap unnamed candidates, not just drop-count. Exhaustive 1..3-subsets of
+# an uncapped pool is O(d^3) reconciles per receipt; a long ITEMS zone of
+# numeric bands (or PR2 splitting one band into many) would blow the
+# Lambda budget. Later bands are preferred — totals sit below items.
+_MAX_CONSTRAINT_CANDIDATES = 8
 
 
 def _priced_for_reconcile(
@@ -1472,6 +1477,8 @@ def constrain_items_to_baseline(
         if not item.get("is_discount")
         and not _name_is_real(str(item.get("name") or ""))
     ]
+    if len(droppable) > _MAX_CONSTRAINT_CANDIDATES:
+        droppable = droppable[-_MAX_CONSTRAINT_CANDIDATES:]
     max_k = min(_MAX_CONSTRAINT_DROPS, len(droppable))
     for k in range(1, max_k + 1):
         for combo in combinations(droppable, k):

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -1464,8 +1464,10 @@ def constrain_items_to_baseline(
                     else 99.0
                 ),
                 len(drop),
-                # Prefer dropping later bands (totals sit below items).
-                -max(drop) if drop else 0,
+                # Prefer later bands at every position, not just max(drop).
+                # Otherwise (0, 7) sorts before (6, 7) and an early real
+                # unnamed item can lose to a later phantom.
+                tuple(-i for i in sorted(drop, reverse=True)),
                 drop,
                 after,
             )

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -1373,10 +1373,12 @@ def is_proven(
 # either side has no comparable baseline.
 _BOUNDARY_RECON_RANK = {"match": 0, "near": 1, "mismatch": 2}
 _MAX_CONSTRAINT_DROPS = 3
-# Cap unnamed candidates, not just drop-count. Exhaustive 1..3-subsets of
-# an uncapped pool is O(d^3) reconciles per receipt; a long ITEMS zone of
-# numeric bands (or PR2 splitting one band into many) would blow the
-# Lambda budget. Later bands are preferred — totals sit below items.
+# Cap unnamed / discount candidates, not just drop-count. Exhaustive
+# 1..3-subsets of an uncapped pool is O(d^3) reconciles per receipt; a
+# long ITEMS zone of numeric bands (or PR2 splitting one band into many)
+# would blow the Lambda budget. ``decode_band_blocks`` emits bottom-of-
+# receipt first, so the search window is the *first* N candidates — the
+# foot, where totals and tender overage sit.
 _MAX_CONSTRAINT_CANDIDATES = 8
 
 
@@ -1401,6 +1403,50 @@ def _recon_eval(result: ReconcileResult) -> dict[str, Any]:
     return {"status": result.status, "delta": delta}
 
 
+def _constraint_guard(before: dict[str, Any], after: dict[str, Any]) -> bool:
+    """Accept a constraint candidate using the ITEMS-boundary guard.
+
+    ``no-baseline`` is omitted from ``_BOUNDARY_RECON_RANK`` because an
+    ITEMS *extension* cannot be verified without a comparable baseline.
+    This post-pass still has the printed summary: an item-sum that
+    tripped the 3x sanity check can become an exact match once discounts
+    count or a phantom band drops, and that match is accepted.
+    """
+
+    if before.get("status") == "no-baseline":
+        return (
+            after.get("status") == "match" and after.get("delta") is not None
+        )
+    verified, _ = items_boundary_extension_guard(before, after)
+    return verified
+
+
+def _is_unnamed_priced_band(item: dict) -> bool:
+    """True when the band has no alphabetic product name.
+
+    ``_name_is_real`` is a decoder quality heuristic (three letters), not
+    an absence-of-name test — ``7UP`` / ``WD-40`` must not be droppable.
+    Quantity-only bands like ``2`` have no letters and stay candidates.
+    """
+
+    name = str(item.get("name") or "").strip()
+    if not name:
+        return True
+    return re.search(r"[A-Za-z]", name) is None
+
+
+def _recon_sort_key(result: ReconcileResult, extra: tuple = ()) -> tuple:
+    return (
+        _BOUNDARY_RECON_RANK.get(result.status, 9),
+        (
+            abs(result.item_sum - result.baseline)
+            if result.item_sum is not None and result.baseline is not None
+            else 99.0
+        ),
+        *extra,
+    )
+
+
 def reconcile_extracted_items(
     items: list[dict], summary: Optional[dict]
 ) -> ReconcileResult:
@@ -1408,8 +1454,8 @@ def reconcile_extracted_items(
 
     The historical sum skipped ``is_discount`` rows, which over-counts
     BOGO / void lines that already sit in ITEMS (the discount is the
-    arithmetic). Including discounts is accepted only when it strictly
-    shrinks ``|delta|`` and improves status — the same guard as an
+    arithmetic). Discount subsets are accepted only when they strictly
+    shrink ``|delta|`` and improve status — the same guard as an
     ITEMS-boundary repair. A receipt that already matches without
     discounts is left alone.
     """
@@ -1417,13 +1463,34 @@ def reconcile_extracted_items(
     excluded = reconcile_detailed(_priced_for_reconcile(items, False), summary)
     if excluded.status == "match" or summary is None:
         return excluded
-    included = reconcile_detailed(_priced_for_reconcile(items, True), summary)
-    if included.item_sum == excluded.item_sum:
+
+    discount_idx = [
+        i for i, item in enumerate(items) if item.get("is_discount")
+    ]
+    if not discount_idx:
         return excluded
-    verified, _ = items_boundary_extension_guard(
-        _recon_eval(excluded), _recon_eval(included)
-    )
-    return included if verified else excluded
+    if len(discount_idx) > _MAX_CONSTRAINT_CANDIDATES:
+        discount_idx = discount_idx[:_MAX_CONSTRAINT_CANDIDATES]
+
+    before = _recon_eval(excluded)
+    best = excluded
+    best_key = _recon_sort_key(excluded, (0,))
+    for k in range(1, len(discount_idx) + 1):
+        for combo in combinations(discount_idx, k):
+            include = set(combo)
+            priced = [
+                item
+                for i, item in enumerate(items)
+                if not item.get("is_discount") or i in include
+            ]
+            candidate = reconcile_detailed(priced, summary)
+            if not _constraint_guard(before, _recon_eval(candidate)):
+                continue
+            key = _recon_sort_key(candidate, (k,))
+            if key < best_key:
+                best = candidate
+                best_key = key
+    return best
 
 
 def constrain_items_to_baseline(
@@ -1433,9 +1500,9 @@ def constrain_items_to_baseline(
 
     No merchant vocabulary: unnamed non-discount bands are candidates
     (a named product coincidentally priced at the gap must survive), and
-    a drop ships only when ``items_boundary_extension_guard`` accepts
-    it. Discounts are never dropped; ``reconcile_extracted_items``
-    decides whether they count. Already-matching receipts are untouched.
+    a drop ships only when ``_constraint_guard`` accepts it. Discounts
+    are never dropped; ``reconcile_extracted_items`` decides whether
+    they count. Already-matching receipts are untouched.
     """
 
     if not items or summary is None:
@@ -1452,35 +1519,26 @@ def constrain_items_to_baseline(
         if not remaining:
             return
         after = reconcile_extracted_items(remaining, summary)
-        verified, _ = items_boundary_extension_guard(before, _recon_eval(after))
-        if not verified:
+        if not _constraint_guard(before, _recon_eval(after)):
             return
         winners.append(
             (
-                _BOUNDARY_RECON_RANK.get(after.status, 9),
-                (
-                    abs(after.item_sum - after.baseline)
-                    if after.item_sum is not None and after.baseline is not None
-                    else 99.0
-                ),
-                len(drop),
+                *_recon_sort_key(after, (len(drop),)),
                 # Prefer later bands at every position, not just max(drop).
                 # Otherwise (0, 7) sorts before (6, 7) and an early real
                 # unnamed item can lose to a later phantom.
                 tuple(-i for i in sorted(drop, reverse=True)),
                 drop,
-                after,
             )
         )
 
     droppable = [
         i
         for i, item in enumerate(items)
-        if not item.get("is_discount")
-        and not _name_is_real(str(item.get("name") or ""))
+        if not item.get("is_discount") and _is_unnamed_priced_band(item)
     ]
     if len(droppable) > _MAX_CONSTRAINT_CANDIDATES:
-        droppable = droppable[-_MAX_CONSTRAINT_CANDIDATES:]
+        droppable = droppable[:_MAX_CONSTRAINT_CANDIDATES]
     max_k = min(_MAX_CONSTRAINT_DROPS, len(droppable))
     for k in range(1, max_k + 1):
         for combo in combinations(droppable, k):
@@ -1488,7 +1546,7 @@ def constrain_items_to_baseline(
     if not winners:
         return items
     winners.sort()
-    return [item for i, item in enumerate(items) if i not in winners[0][4]]
+    return [item for i, item in enumerate(items) if i not in winners[0][-1]]
 
 
 def evaluate_items_zone(
@@ -1758,7 +1816,9 @@ def propose_items_boundary_extension(
                 for candidate in candidate_rows
                 for line_id in candidate["line_ids"]
             }
-            evaluation = evaluate_items_zone(words, summary, candidate_line_ids)
+            evaluation = evaluate_items_zone(
+                words, summary, candidate_line_ids
+            )
             if evaluation.get("delta") is not None and abs(
                 evaluation["delta"]
             ) < abs(current_evaluation["delta"]):

--- a/receipt_upload/receipt_upload/line_items/labels.py
+++ b/receipt_upload/receipt_upload/line_items/labels.py
@@ -47,7 +47,7 @@ from receipt_upload.line_items.geometry import (
     extract_items,
     is_column_header_row,
     is_proven,
-    reconcile_detailed,
+    reconcile_extracted_items,
 )
 from receipt_upload.line_items.reconstructor import dedupe_grand_total
 
@@ -543,9 +543,7 @@ def _summary_labels(
         ]
         unique = {(int(w.line_id), int(w.word_id)): w for w in matches}
         if label == "GRAND_TOTAL":
-            word = _elect_grand_total_word(
-                receipt_words, list(unique.values())
-            )
+            word = _elect_grand_total_word(receipt_words, list(unique.values()))
             if word is None:
                 continue
             line_id, word_id = int(word.line_id), int(word.word_id)
@@ -713,8 +711,7 @@ def _phone_spans(words: Sequence[Any]) -> list[list[Any]]:
         (start, end)
         for start, end in spans
         if not any(
-            (s, e) != (start, end) and s <= start and end <= e
-            for s, e in spans
+            (s, e) != (start, end) and s <= start and end <= e for s, e in spans
         )
     ]
     return [list(words[start:end]) for start, end in maximal]
@@ -906,9 +903,7 @@ def derive_labels(
     texts = {(w["line_id"], w["word_id"]): w["text"] for w in words}
 
     items, collapsed = extract_items(words, line_ids, summary=summary)
-    recon = reconcile_detailed(
-        [item for item in items if not item.get("is_discount")], summary
-    )
+    recon = reconcile_extracted_items(items, summary)
     result = DerivationResult(
         gate=GATE_OK,
         reconciliation_status=recon.status,

--- a/receipt_upload/receipt_upload/line_items/labels.py
+++ b/receipt_upload/receipt_upload/line_items/labels.py
@@ -543,7 +543,9 @@ def _summary_labels(
         ]
         unique = {(int(w.line_id), int(w.word_id)): w for w in matches}
         if label == "GRAND_TOTAL":
-            word = _elect_grand_total_word(receipt_words, list(unique.values()))
+            word = _elect_grand_total_word(
+                receipt_words, list(unique.values())
+            )
             if word is None:
                 continue
             line_id, word_id = int(word.line_id), int(word.word_id)
@@ -711,7 +713,8 @@ def _phone_spans(words: Sequence[Any]) -> list[list[Any]]:
         (start, end)
         for start, end in spans
         if not any(
-            (s, e) != (start, end) and s <= start and end <= e for s, e in spans
+            (s, e) != (start, end) and s <= start and end <= e
+            for s, e in spans
         )
     ]
     return [list(words[start:end]) for start, end in maximal]

--- a/receipt_upload/tests/test_baseline_constraint.py
+++ b/receipt_upload/tests/test_baseline_constraint.py
@@ -96,6 +96,22 @@ def test_no_summary_is_a_no_op():
     assert constrain_items_to_baseline(items, None) is items
 
 
+def test_prefers_later_unnamed_when_drop_sets_share_max_index():
+    # Three identical unnamed $1 bands; dropping any two matches.
+    # Names shorter than _name_is_real stay droppable. Later-band
+    # preference must keep the earliest ("A"), not the middle ("B"):
+    # without a full descending-index key, (A,C) sorts before (B,C).
+    items = [
+        _item(1.00, "A"),
+        _item(1.00, "B"),
+        _item(1.00, "C"),
+        _item(5.00, "MILK"),
+    ]
+    summary = {"subtotal": 6.00}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["name"] for i in constrained] == ["A", "MILK"]
+
+
 def test_candidate_cap_skips_early_unnamed_outside_the_window():
     # Eight later unnamed bands fill the search window; the real
     # overage sits above them and is left alone. That is the bound

--- a/receipt_upload/tests/test_baseline_constraint.py
+++ b/receipt_upload/tests/test_baseline_constraint.py
@@ -1,0 +1,96 @@
+"""Printed-total constraint: count ITEMS discounts / drop extra bands.
+
+No merchant vocabulary. A change ships only when the same arithmetic
+guard as ITEMS-boundary repair accepts it (strictly smaller |delta|
+AND a better reconciliation status).
+"""
+
+from receipt_upload.line_items.geometry import (
+    constrain_items_to_baseline,
+    reconcile_extracted_items,
+)
+
+
+def _item(price, name="MILK", is_discount=False):
+    return {
+        "name": name,
+        "price": price,
+        "is_discount": is_discount,
+        "line_ids": [1],
+    }
+
+
+def test_bogo_discount_counts_when_it_closes_the_delta():
+    # Two full-price pennesi plus the printed BOGO -$2. Excluding the
+    # discount over-counts by exactly $2; including it matches.
+    items = [
+        _item(3.99, "PENNE"),
+        _item(3.99, "PENNE"),
+        _item(-2.00, "BOGO 50% OFF GROC", is_discount=True),
+    ]
+    summary = {"subtotal": 5.98}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["price"] for i in constrained] == [3.99, 3.99, -2.00]
+    recon = reconcile_extracted_items(constrained, summary)
+    assert recon.status == "match"
+    assert recon.item_sum == 5.98
+
+
+def test_already_matching_receipt_is_untouched():
+    items = [_item(4.99, "EGGS"), _item(3.99, "MILK")]
+    summary = {"subtotal": 8.98}
+    assert constrain_items_to_baseline(items, summary) == items
+    assert reconcile_extracted_items(items, summary).status == "match"
+
+
+def test_phantom_unit_price_drops_when_it_is_the_overage():
+    # 2 @ 8.99 decoded as $17.98 AND the unit price $8.99.
+    items = [_item(17.98, "ORG CHICKEN SAUSAGE"), _item(8.99, "2")]
+    summary = {"subtotal": 17.98}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["price"] for i in constrained] == [17.98]
+    assert reconcile_extracted_items(constrained, summary).status == "match"
+
+
+def test_under_count_does_not_drop_real_items():
+    items = [_item(7.99, "MILK"), _item(3.99, "EGGS")]
+    summary = {"subtotal": 17.97}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["price"] for i in constrained] == [7.99, 3.99]
+    assert reconcile_extracted_items(constrained, summary).status == "mismatch"
+
+
+def test_discount_not_counted_when_it_would_overshoot():
+    # Sale prices already net; a leftover coupon line must not be
+    # subtracted just because it exists.
+    items = [
+        _item(5.00, "APPLES"),
+        _item(5.00, "BANANAS"),
+        _item(-1.00, "COUPON", is_discount=True),
+    ]
+    summary = {"subtotal": 10.00}
+    constrained = constrain_items_to_baseline(items, summary)
+    recon = reconcile_extracted_items(constrained, summary)
+    assert recon.status == "match"
+    assert recon.item_sum == 10.00
+
+
+def test_prefers_dropping_unnamed_band_when_prices_tie():
+    items = [_item(5.00, "MILK"), _item(5.00, "")]
+    summary = {"subtotal": 5.00}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["name"] for i in constrained] == ["MILK"]
+
+
+def test_named_item_at_the_overage_survives():
+    # Coffee coincidentally costs the tax amount. Dropping it would
+    # match the subtotal and be wrong.
+    items = [_item(2.33, "COFFEE"), _item(5.00, "BAGEL"), _item(3.00, "MUFFIN")]
+    summary = {"subtotal": 8.00, "grand_total": 10.33, "tax": 2.33}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert sorted(i["price"] for i in constrained) == [2.33, 3.0, 5.0]
+
+
+def test_no_summary_is_a_no_op():
+    items = [_item(1.00), _item(2.00)]
+    assert constrain_items_to_baseline(items, None) is items

--- a/receipt_upload/tests/test_baseline_constraint.py
+++ b/receipt_upload/tests/test_baseline_constraint.py
@@ -11,12 +11,12 @@ from receipt_upload.line_items.geometry import (
 )
 
 
-def _item(price, name="MILK", is_discount=False):
+def _item(price, name="MILK", is_discount=False, line_ids=None):
     return {
         "name": name,
         "price": price,
         "is_discount": is_discount,
-        "line_ids": [1],
+        "line_ids": line_ids or [1],
     }
 
 
@@ -85,7 +85,11 @@ def test_prefers_dropping_unnamed_band_when_prices_tie():
 def test_named_item_at_the_overage_survives():
     # Coffee coincidentally costs the tax amount. Dropping it would
     # match the subtotal and be wrong.
-    items = [_item(2.33, "COFFEE"), _item(5.00, "BAGEL"), _item(3.00, "MUFFIN")]
+    items = [
+        _item(2.33, "COFFEE"),
+        _item(5.00, "BAGEL"),
+        _item(3.00, "MUFFIN"),
+    ]
     summary = {"subtotal": 8.00, "grand_total": 10.33, "tax": 2.33}
     constrained = constrain_items_to_baseline(items, summary)
     assert sorted(i["price"] for i in constrained) == [2.33, 3.0, 5.0]
@@ -98,26 +102,70 @@ def test_no_summary_is_a_no_op():
 
 def test_prefers_later_unnamed_when_drop_sets_share_max_index():
     # Three identical unnamed $1 bands; dropping any two matches.
-    # Names shorter than _name_is_real stay droppable. Later-band
-    # preference must keep the earliest ("A"), not the middle ("B"):
-    # without a full descending-index key, (A,C) sorts before (B,C).
+    # Later-band preference must keep the earliest (bottom-first index
+    # 0), not the middle: without a full descending-index key, (0, 2)
+    # sorts before (1, 2).
     items = [
-        _item(1.00, "A"),
-        _item(1.00, "B"),
-        _item(1.00, "C"),
-        _item(5.00, "MILK"),
+        _item(1.00, "", line_ids=[1]),
+        _item(1.00, "", line_ids=[2]),
+        _item(1.00, "", line_ids=[3]),
+        _item(5.00, "MILK", line_ids=[4]),
     ]
     summary = {"subtotal": 6.00}
     constrained = constrain_items_to_baseline(items, summary)
-    assert [i["name"] for i in constrained] == ["A", "MILK"]
+    assert [i["line_ids"] for i in constrained] == [[1], [4]]
 
 
-def test_candidate_cap_skips_early_unnamed_outside_the_window():
-    # Eight later unnamed bands fill the search window; the real
-    # overage sits above them and is left alone. That is the bound
-    # Codex asked for — not a correctness claim about early phantoms.
-    items = [_item(17.98, "ORG CHICKEN SAUSAGE"), _item(8.99, "")]
-    items.extend(_item(0.50, "") for _ in range(8))
-    summary = {"subtotal": 21.98}
+def test_candidate_cap_searches_bottommost_unnamed():
+    # decode_band_blocks emits bottom-first, so index 0 is the foot.
+    # Nine unnamed bands; the phantom total is the bottommost. The
+    # window must be the first 8 droppables, not the last 8.
+    items = [_item(8.99, "")]
+    items.append(_item(17.98, "ORG CHICKEN SAUSAGE"))
+    items.extend(_item(0.0, "") for _ in range(8))
+    summary = {"subtotal": 17.98}
     constrained = constrain_items_to_baseline(items, summary)
-    assert [i["price"] for i in constrained] == [17.98, 8.99] + [0.50] * 8
+    assert [i["price"] for i in constrained] == [17.98] + [0.0] * 8
+
+
+def test_short_alphanumeric_name_is_not_droppable():
+    # 7UP is a real product; dropping it would match the subtotal.
+    items = [
+        _item(2.00, "7UP"),
+        _item(5.00, "MILK"),
+        _item(3.00, "EGGS"),
+    ]
+    summary = {"subtotal": 8.00}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["name"] for i in constrained] == ["7UP", "MILK", "EGGS"]
+
+
+def test_discount_subset_counts_only_the_closing_discount():
+    items = [
+        _item(6.00, "MILK"),
+        _item(5.00, "EGGS"),
+        _item(-1.00, "COUPON A", is_discount=True),
+        _item(-2.00, "COUPON B", is_discount=True),
+    ]
+    summary = {"subtotal": 10.00}
+    recon = reconcile_extracted_items(items, summary)
+    assert recon.status == "match"
+    assert recon.item_sum == 10.00
+
+
+def test_discount_rescues_item_sum_induced_no_baseline():
+    items = [
+        _item(40.00, "STEAK"),
+        _item(-30.00, "PROMO", is_discount=True),
+    ]
+    summary = {"subtotal": 10.00}
+    recon = reconcile_extracted_items(items, summary)
+    assert recon.status == "match"
+    assert recon.item_sum == 10.00
+
+
+def test_drops_large_unnamed_band_from_no_baseline():
+    items = [_item(10.00, "MILK"), _item(100.00, "")]
+    summary = {"subtotal": 10.00}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["price"] for i in constrained] == [10.00]

--- a/receipt_upload/tests/test_baseline_constraint.py
+++ b/receipt_upload/tests/test_baseline_constraint.py
@@ -94,3 +94,14 @@ def test_named_item_at_the_overage_survives():
 def test_no_summary_is_a_no_op():
     items = [_item(1.00), _item(2.00)]
     assert constrain_items_to_baseline(items, None) is items
+
+
+def test_candidate_cap_skips_early_unnamed_outside_the_window():
+    # Eight later unnamed bands fill the search window; the real
+    # overage sits above them and is left alone. That is the bound
+    # Codex asked for — not a correctness claim about early phantoms.
+    items = [_item(17.98, "ORG CHICKEN SAUSAGE"), _item(8.99, "")]
+    items.extend(_item(0.50, "") for _ in range(8))
+    summary = {"subtotal": 21.98}
+    constrained = constrain_items_to_baseline(items, summary)
+    assert [i["price"] for i in constrained] == [17.98, 8.99] + [0.50] * 8

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -4870,8 +4870,8 @@ def _summary_baseline(record) -> tuple[dict, Optional[float]]:
 def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
     """Run the real extractor over a line set and reconcile.
 
-    Discounts are excluded from the sum, matching the stream stage and
-    scripts/repair_item_sections.evaluate.
+    Uses ``evaluate_items_zone`` so discount-inclusion and unnamed-band
+    drops stay in lockstep with ingest.
     """
     from receipt_upload.line_items.geometry import evaluate_items_zone
 

--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -4878,6 +4878,18 @@ def _evaluate_items_zone(words: list[dict], summary: dict, line_ids) -> dict:
     return evaluate_items_zone(words, summary, set(line_ids))
 
 
+def _reconcile_stored_items(items: list[dict], summary: Optional[dict]):
+    """Discount-aware sum for stored rows; same helper as ingest.
+
+    Deferred import matches ``_evaluate_items_zone``: this module loads
+    in tests with a stub ``mcp`` package before upload extras are
+    guaranteed at import time.
+    """
+    from receipt_upload.line_items.geometry import reconcile_extracted_items
+
+    return reconcile_extracted_items(items, summary)
+
+
 async def get_receipt_line_items_impl(
     dynamo_client, image_id: str, receipt_id: int
 ) -> dict:
@@ -4925,18 +4937,29 @@ async def get_receipt_line_items_impl(
             }
             for li in line_items
         ]
-        # Discounts excluded from the sum, matching reconcile()'s callers
-        # (the stream stage and repair_item_sections.evaluate).
-        items_sum = round(
-            sum(float(li.price) for li in line_items if not li.is_discount),
-            2,
-        )
+        priced = [
+            {
+                "price": float(li.price),
+                "is_discount": bool(li.is_discount),
+            }
+            for li in line_items
+        ]
 
-        summary = None
+        figures = None
         baseline = None
+        summary = None
         if record is not None:
             figures, baseline = _summary_baseline(record)
             summary = {**figures, "merchant_name": record.merchant_name}
+        recon = _reconcile_stored_items(priced, figures)
+        items_sum = recon.item_sum
+        if items_sum is None:
+            items_sum = round(
+                sum(p["price"] for p in priced if not p["is_discount"]),
+                2,
+            )
+        if recon.baseline is not None:
+            baseline = recon.baseline
         delta = (
             round(items_sum - baseline, 2) if baseline is not None else None
         )
@@ -5235,13 +5258,17 @@ async def list_reconciliation_worklist_impl(
                     {
                         "merchant": None,
                         "items": 0,
-                        "items_sum": 0.0,
+                        "priced": [],
                         "statuses": set(),
                     },
                 )
                 bucket["items"] += 1
-                if not li.is_discount:
-                    bucket["items_sum"] += float(li.price)
+                bucket["priced"].append(
+                    {
+                        "price": float(li.price),
+                        "is_discount": bool(li.is_discount),
+                    }
+                )
                 if li.merchant_name and not bucket["merchant"]:
                     bucket["merchant"] = li.merchant_name
                 if li.reconciliation_status:
@@ -5271,23 +5298,36 @@ async def list_reconciliation_worklist_impl(
                     "receipt_id": rid,
                     "merchant": bucket["merchant"],
                     "items": bucket["items"],
-                    "items_sum": round(bucket["items_sum"], 2),
+                    "priced": bucket["priced"],
                 }
             )
 
         for i, cand in enumerate(candidates):
+            priced = cand.pop("priced")
+            excluded_sum = round(
+                sum(p["price"] for p in priced if not p["is_discount"]),
+                2,
+            )
+            figures = None
             baseline = None
             if i < max_summary_fetches:
                 try:
                     record = dynamo_client.get_receipt_summary(
                         cand["image_id"], cand["receipt_id"]
                     )
-                    _, baseline = _summary_baseline(record)
+                    figures, baseline = _summary_baseline(record)
                 except EntityNotFoundError:
-                    baseline = None
+                    figures, baseline = None, None
+            recon = _reconcile_stored_items(priced, figures)
+            items_sum = (
+                recon.item_sum if recon.item_sum is not None else excluded_sum
+            )
+            if recon.baseline is not None:
+                baseline = recon.baseline
+            cand["items_sum"] = items_sum
             cand["subtotal"] = baseline
             cand["delta"] = (
-                round(cand["items_sum"] - baseline, 2)
+                round(items_sum - baseline, 2)
                 if baseline is not None
                 else None
             )

--- a/tests/test_receipt_mcp_line_item_tools.py
+++ b/tests/test_receipt_mcp_line_item_tools.py
@@ -351,7 +351,8 @@ def test_get_receipt_line_items_diagnostic_view(label):
 
     assert "error" not in result
     assert result["item_count"] == 3
-    # Discounts are excluded from the sum, matching reconcile()'s callers.
+    # Leftover coupon is not in the printed subtotal, so the helper
+    # keeps the discount-excluded sum.
     assert result["items_sum"] == 5.00
     assert result["summary"]["subtotal"] == 9.00
     assert result["summary"]["merchant_name"] == "Test Mart"
@@ -364,6 +365,29 @@ def test_get_receipt_line_items_diagnostic_view(label):
     assert first["price"] == 3.00
     assert first["extractor_version"] == "line-items-blocks-v2"
     assert first["name_quality"] == "ok"
+
+
+@pytest.mark.parametrize("label", sorted(SERVER_FILES))
+def test_get_receipt_line_items_counts_bogo_discount(label):
+    pytest.importorskip("receipt_dynamo")
+    module = _load_module(label, SERVER_FILES[label])
+    client = _StubDynamoClient(
+        sections=[_items_section(line_ids=(1, 2, 3))],
+        summary_record=_summary_record(
+            subtotal=5.98, tax=0.48, grand_total=6.46
+        ),
+        line_items=[
+            _line_item(0, "PENNE", "3.99"),
+            _line_item(1, "PENNE", "3.99"),
+            _line_item(2, "BOGO", "-2.00", is_discount=True),
+        ],
+    )
+    result = asyncio.run(
+        module.get_receipt_line_items_impl(client, VALID_IMAGE_ID, 1)
+    )
+    assert "error" not in result
+    assert result["items_sum"] == 5.98
+    assert result["delta"] == 0.00
 
 
 @pytest.mark.parametrize("label", sorted(SERVER_FILES))


### PR DESCRIPTION
## Summary

- Treat the printed baseline as a **constraint** on `extract_items`, not a new merchant vocabulary: count ITEMS discounts when they close the delta, and drop unnamed extra bands only when `items_boundary_extension_guard` accepts.
- Named products coincidentally priced at the gap (coffee = tax) are left alone. No Dynamo schema change — discounts already use `is_discount` + negative `price`.
- Live A/B on 187 Sprouts GSI1 receipts (dev, read-only): **84.0% → 89.3% match** (+10, 0 regressions). Remaining misses are glued two-name bands, unread `lb @` / zone gaps, and 5 no-baseline totals — stacked follow-ups, not this diff.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Which Package(s) are Affected?

- [x] receipt_upload
- [x] Infrastructure (Pulumi)

(Lambda `line_item_processor` and MCP evaluate wrappers now call the same `evaluate_items_zone` / `extract_items` path so ingest and tools cannot fork.)

## Testing

- [x] Unit tests pass locally (`pytest receipt_upload/tests/test_baseline_constraint.py receipt_upload/tests/test_line_item_golden_regression.py`)
- [x] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes
- [x] Manual testing completed (if applicable)

Golden merchant floors were not lowered. Golden `extract_items` often has `summary=None`, so constrain is a no-op there by design — the stream recompute and `LINE_ITEM_REFINE` are the paths that have a summary.

## Pipeline fit

This runs where structured data is already produced from the image:

`image → Mac Vision OCR → LayoutLM furniture → sections → extract_items` (Mac + cloud) → stream recompute on summary.

`constrain_items_to_baseline` is a post-pass on `extract_items` when `summary` is present. First-pass Mac decode without a summary is unchanged; cloud recompute (canonical) and the gated `LINE_ITEM_REFINE` pass see the constraint. Swift port of the post-pass is a follow-up — cloud wins ties today.

Does **not** feed LayoutLM product labels into the section finder.

## Documentation & Code Quality

- [x] Documentation or comments updated for complex logic

## Related Issues

Stacked next (do not mix into this PR):

1. Two-column / over-merged band split inside `decode_band_blocks` (glued names, repeating `−$5.99`)
2. Zone-gap + produce-by-weight (`lb @` as quantity metadata, extend ITEMS only when decode emits a new priced item)
3. Recover no-baseline totals from `TOTAL_LINE` furniture

## Impact Analysis

Cloud line-item recompute will drop unnamed phantom bands and include discounts when arithmetic improves. Worker-written rows are preserved only if they still beat the cloud by the same guard.

## Deployment Notes

No Pulumi resource changes. Ships with the next `receipt_upload` / line-item updater image rebuild. No schema migration. Rollback is revert.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt total reconciliation, including discount-aware handling such as BOGO items.
  * Prevented phantom or unnamed items from causing incorrect totals.
  * Preserved valid named items and avoided adjustments that worsen reconciliation.
  * Applied consistent item evaluation across receipt processing and diagnostics.

* **Tests**
  * Added coverage for discount handling, item preservation, baseline matching, candidate selection, and receipts without summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->