### PR TITLE
fix(summary): recover printed totals from TOTAL_LINE despite OCR junk

### DIFF
--- a/infra/receipt_summary_updater/summary_processor.py
+++ b/infra/receipt_summary_updater/summary_processor.py
@@ -26,6 +26,26 @@ TABLE_NAME = os.environ.get("DYNAMODB_TABLE_NAME", "")
 dynamo_client = DynamoClient(TABLE_NAME) if TABLE_NAME else None
 
 
+def _total_line_ids(sections: list[Any] | None) -> list[int]:
+    """TOTAL_LINE section line ids from dict or entity section records."""
+    ids: list[int] = []
+    for section in sections or []:
+        if isinstance(section, dict):
+            section_type = section.get("section_type")
+            line_ids = section.get("line_ids") or []
+        else:
+            section_type = getattr(section, "section_type", None)
+            line_ids = getattr(section, "line_ids", None) or []
+        if section_type != "TOTAL_LINE":
+            continue
+        for line_id in line_ids:
+            try:
+                ids.append(int(line_id))
+            except (TypeError, ValueError):
+                continue
+    return ids
+
+
 def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
     """Recompute and upsert ReceiptSummary for a receipt.
 
@@ -85,10 +105,8 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
     word_labels = []
     last_key = None
     while True:
-        page_labels, last_key = (
-            dynamo_client.list_receipt_word_labels_for_receipt(
-                image_id, receipt_id, last_evaluated_key=last_key
-            )
+        page_labels, last_key = dynamo_client.list_receipt_word_labels_for_receipt(
+            image_id, receipt_id, last_evaluated_key=last_key
         )
         word_labels.extend(page_labels)
         if last_key is None:
@@ -98,10 +116,9 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
 
     # Lines + sections feed the tender classifier's payment zone
     lines = dynamo_client.list_receipt_lines_from_receipt(image_id, receipt_id)
-    sections = dynamo_client.get_receipt_sections_from_receipt(
-        image_id, receipt_id
-    )
+    sections = dynamo_client.get_receipt_sections_from_receipt(image_id, receipt_id)
     tender = classify_tender_for_receipt(lines, sections, word_labels, words)
+    total_line_ids = _total_line_ids(sections)
 
     # Bank-match fields are computed OFFLINE (scripts/
     # backfill_tender_bank.py); carry them over from the stored summary
@@ -144,9 +161,7 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
     # unbounded recompute loop.
     try:
         line_item_count = len(
-            dynamo_client.get_receipt_line_items_from_receipt(
-                image_id, receipt_id
-            )
+            dynamo_client.get_receipt_line_items_from_receipt(image_id, receipt_id)
         )
     except EntityNotFoundError:
         line_item_count = 0
@@ -165,6 +180,7 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
         bank_amount=bank_amount,
         bank_match_confidence=bank_match_confidence,
         line_item_count=line_item_count,
+        total_line_ids=total_line_ids,
     )
 
     # Convert to record and upsert

--- a/infra/receipt_summary_updater/summary_processor.py
+++ b/infra/receipt_summary_updater/summary_processor.py
@@ -9,6 +9,8 @@ import logging
 import os
 from typing import Any
 
+from receipt_upload.tender import classify_tender_for_receipt
+
 # receipt_dynamo ships in the Lambda layer; receipt_upload.tender is
 # bundled into this Lambda's archive as a FileAsset referencing the
 # canonical source (stdlib-only module, same pattern as the line-item
@@ -17,7 +19,6 @@ from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 from receipt_dynamo.entities.receipt_summary import ReceiptSummary
 from receipt_dynamo.entities.receipt_summary_record import ReceiptSummaryRecord
-from receipt_upload.tender import classify_tender_for_receipt
 
 logger = logging.getLogger(__name__)
 
@@ -105,8 +106,10 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
     word_labels = []
     last_key = None
     while True:
-        page_labels, last_key = dynamo_client.list_receipt_word_labels_for_receipt(
-            image_id, receipt_id, last_evaluated_key=last_key
+        page_labels, last_key = (
+            dynamo_client.list_receipt_word_labels_for_receipt(
+                image_id, receipt_id, last_evaluated_key=last_key
+            )
         )
         word_labels.extend(page_labels)
         if last_key is None:
@@ -116,7 +119,9 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
 
     # Lines + sections feed the tender classifier's payment zone
     lines = dynamo_client.list_receipt_lines_from_receipt(image_id, receipt_id)
-    sections = dynamo_client.get_receipt_sections_from_receipt(image_id, receipt_id)
+    sections = dynamo_client.get_receipt_sections_from_receipt(
+        image_id, receipt_id
+    )
     tender = classify_tender_for_receipt(lines, sections, word_labels, words)
     total_line_ids = _total_line_ids(sections)
 
@@ -161,7 +166,9 @@ def update_receipt_summary(image_id: str, receipt_id: int) -> dict[str, Any]:
     # unbounded recompute loop.
     try:
         line_item_count = len(
-            dynamo_client.get_receipt_line_items_from_receipt(image_id, receipt_id)
+            dynamo_client.get_receipt_line_items_from_receipt(
+                image_id, receipt_id
+            )
         )
     except EntityNotFoundError:
         line_item_count = 0

--- a/infra/receipt_summary_updater/summary_processor.py
+++ b/infra/receipt_summary_updater/summary_processor.py
@@ -9,8 +9,6 @@ import logging
 import os
 from typing import Any
 
-from receipt_upload.tender import classify_tender_for_receipt
-
 # receipt_dynamo ships in the Lambda layer; receipt_upload.tender is
 # bundled into this Lambda's archive as a FileAsset referencing the
 # canonical source (stdlib-only module, same pattern as the line-item
@@ -19,6 +17,7 @@ from receipt_dynamo.data.dynamo_client import DynamoClient
 from receipt_dynamo.data.shared_exceptions import EntityNotFoundError
 from receipt_dynamo.entities.receipt_summary import ReceiptSummary
 from receipt_dynamo.entities.receipt_summary_record import ReceiptSummaryRecord
+from receipt_upload.tender import classify_tender_for_receipt
 
 logger = logging.getLogger(__name__)
 

--- a/receipt_dynamo/receipt_dynamo/amounts.py
+++ b/receipt_dynamo/receipt_dynamo/amounts.py
@@ -18,9 +18,7 @@ _CURRENCY_SYMBOLS = r"$€£¥₹"
 # import them without forking the regexes.
 # ---------------------------------------------------------------------------
 
-TOTAL_KEYWORD_RE = re.compile(
-    r"\b(total|amount\s+due|balance|authorized)\b", re.I
-)
+TOTAL_KEYWORD_RE = re.compile(r"\b(total|amount\s+due|balance|authorized)\b", re.I)
 SUBTOTAL_KEYWORD_RE = re.compile(r"\bsub[-\s]?total\b", re.I)
 TAX_KEYWORD_RE = re.compile(r"\b(tax|vat)\b", re.I)
 NON_PAYMENT_SUMMARY_RE = re.compile(
@@ -83,9 +81,7 @@ def is_grand_total_line(line_text: str) -> bool:
         return False
     if NON_PAYMENT_SUMMARY_RE.search(line_text):
         return False
-    tokens = {
-        token for token in re.split(r"[^a-z]+", line_text.lower()) if token
-    }
+    tokens = {token for token in re.split(r"[^a-z]+", line_text.lower()) if token}
     return not (tokens & GRAND_TOTAL_DISQUALIFIER_TOKENS)
 
 
@@ -93,8 +89,10 @@ def parse_receipt_amount(text: Any) -> float | None:
     """Parse receipt currency/amount text without changing the OCR text.
 
     Handles US-style amounts (``1,234.56``), decimal-comma amounts
-    (``8,82``), European grouped amounts (``1.234,56``), and negative
-    accounting forms.
+    (``8,82``), European grouped amounts (``1.234,56``), negative
+    accounting forms, and OCR-mangled currency prefixes (``USD$S 7.43``,
+    ``USD$S7.43``). Letters and doubled ``$`` wrappers are stripped; the
+    figure itself must still be on the token.
     """
     if text is None:
         return None
@@ -133,17 +131,26 @@ def parse_receipt_amount(text: Any) -> float | None:
     return -value if is_negative else value
 
 
+_DECIMAL_AMOUNT_RE = re.compile(r"-?\(?\d+([.,]\d{2})\)?-?")
+_GROUPED_AMOUNT_RE = re.compile(r"-?\(?\d{1,3}(,\d{3})+(\.\d{2})?\)?-?")
+
+
 def looks_like_receipt_amount(text: Any) -> bool:
-    """Return whether text has receipt amount punctuation/symbol context."""
+    """Return whether text has receipt amount punctuation/symbol context.
+
+    Currency-only OCR junk (``USD$S``, ``USD$``) is not an amount: a
+    digit must be present. A ``$`` still glued to the figure
+    (``USD$S 7.43``) qualifies via the currency-symbol check.
+    """
     if text is None:
         return False
     raw = str(text).strip()
-    if not raw:
+    if not raw or not re.search(r"\d", raw):
         return False
     return bool(
         re.search(f"[{re.escape(_CURRENCY_SYMBOLS)}]", raw)
-        or re.fullmatch(r"-?\(?\d{1,3}(,\d{3})+(\.\d{2})?\)?-?", raw)
-        or re.fullmatch(r"-?\(?\d+([.,]\d{2})\)?-?", raw)
+        or _GROUPED_AMOUNT_RE.fullmatch(raw)
+        or _DECIMAL_AMOUNT_RE.fullmatch(raw)
     )
 
 

--- a/receipt_dynamo/receipt_dynamo/amounts.py
+++ b/receipt_dynamo/receipt_dynamo/amounts.py
@@ -18,7 +18,9 @@ _CURRENCY_SYMBOLS = r"$€£¥₹"
 # import them without forking the regexes.
 # ---------------------------------------------------------------------------
 
-TOTAL_KEYWORD_RE = re.compile(r"\b(total|amount\s+due|balance|authorized)\b", re.I)
+TOTAL_KEYWORD_RE = re.compile(
+    r"\b(total|amount\s+due|balance|authorized)\b", re.I
+)
 SUBTOTAL_KEYWORD_RE = re.compile(r"\bsub[-\s]?total\b", re.I)
 TAX_KEYWORD_RE = re.compile(r"\b(tax|vat)\b", re.I)
 NON_PAYMENT_SUMMARY_RE = re.compile(
@@ -81,7 +83,9 @@ def is_grand_total_line(line_text: str) -> bool:
         return False
     if NON_PAYMENT_SUMMARY_RE.search(line_text):
         return False
-    tokens = {token for token in re.split(r"[^a-z]+", line_text.lower()) if token}
+    tokens = {
+        token for token in re.split(r"[^a-z]+", line_text.lower()) if token
+    }
     return not (tokens & GRAND_TOTAL_DISQUALIFIER_TOKENS)
 
 

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -261,6 +261,7 @@ class _ExtractionState:
     """Mutable state for label extraction."""
 
     grand_total: float | None = None
+    grand_total_line_id: int | None = None
     subtotal: float | None = None
     tax: float | None = None
     tip: float | None = None
@@ -336,7 +337,7 @@ def _extract_summary_fields(
         word_text_lookup: Mapping from (line_id, word_id) to word text.
 
     Returns:
-        Tuple of (totals, date, item_count).
+        Tuple of (totals, date, item_count, grand_total_line_id).
     """
     state = _ExtractionState()
     date_words_by_line: dict[int, list[tuple[int, str]]] = {}
@@ -349,7 +350,14 @@ def _extract_summary_fields(
         handler = _LABEL_HANDLERS.get(label.label)
         if handler:
             text = word_text_lookup.get((label.line_id, label.word_id), "")
+            prev_grand_total = state.grand_total
             handler(text, state)
+            if (
+                label.label == "GRAND_TOTAL"
+                and state.grand_total is not None
+                and state.grand_total != prev_grand_total
+            ):
+                state.grand_total_line_id = int(label.line_id)
             if label.label == "DATE":
                 date_words_by_line.setdefault(label.line_id, []).append(
                     (label.word_id, text)
@@ -372,7 +380,7 @@ def _extract_summary_fields(
         tax=state.tax,
         tip=state.tip,
     )
-    return totals, state.date, state.item_count
+    return totals, state.date, state.item_count, state.grand_total_line_id
 
 
 # =============================================================================
@@ -405,20 +413,6 @@ def _word_height(word: "ReceiptWord") -> float:
     return box.get("height") or 0.0
 
 
-def _positive_amount(text: str) -> float | None:
-    """Parse text as a positive printed amount, else None.
-
-    Requires amount-like punctuation (decimals or a currency symbol) so
-    bare integers such as store numbers never qualify.
-    """
-    if not looks_like_receipt_amount(text):
-        return None
-    value = parse_receipt_amount(text)
-    if value is None or value <= 0:
-        return None
-    return value
-
-
 _CURRENCY_PREFIX_RE = re.compile(r"(?:[A-Za-z]{2,3})?\$+S?", re.I)
 _ISO_CURRENCY_PREFIX_RE = re.compile(r"(?:USD|EUR|GBP|CAD|AUD|JPY|MXN|CHF)S?", re.I)
 
@@ -434,14 +428,17 @@ def _is_currency_prefix_token(text: str) -> bool:
     )
 
 
-def _amount_words_on_line(
+_MINUS_TOKENS = frozenset({"-", "−", "–", "—"})
+
+
+def _signed_amount_words_on_line(
     line_words: list["ReceiptWord"],
 ) -> list[tuple[float, "ReceiptWord"]]:
-    """Positive amounts on a line, including split currency+number tokens.
+    """Signed amounts on a line, including split currency and minus tokens.
 
-    Vision OCR often emits ``USD$S`` and ``7.43`` as adjacent words.
-    The numeric word is the one returned so callers can point a label
-    at the printed figure.
+    Vision OCR often emits ``USD$S`` + ``7.43``, or ``-`` + ``6.00``, as
+    adjacent words. The numeric word is the one returned so callers can
+    point a label at the printed figure.
     """
     found: list[tuple[float, "ReceiptWord"]] = []
     texts = [str(getattr(w, "text", "") or "") for w in line_words]
@@ -449,25 +446,43 @@ def _amount_words_on_line(
     for i, word in enumerate(line_words):
         if i in seen:
             continue
-        amount = _positive_amount(texts[i])
-        if amount is not None:
-            found.append((amount, word))
-            seen.add(i)
-            continue
-        if i + 1 < len(line_words) and _is_currency_prefix_token(texts[i]):
-            joined = f"{texts[i]} {texts[i + 1]}"
-            amount = _positive_amount(joined)
-            if amount is not None:
-                found.append((amount, line_words[i + 1]))
+        if texts[i] in _MINUS_TOKENS and i + 1 < len(line_words):
+            value = parse_receipt_amount(f"-{texts[i + 1]}")
+            if value is not None:
+                found.append((value, line_words[i + 1]))
                 seen.add(i)
                 seen.add(i + 1)
+                continue
+        if i + 1 < len(line_words) and _is_currency_prefix_token(texts[i]):
+            value = parse_receipt_amount(f"{texts[i]} {texts[i + 1]}")
+            if value is not None:
+                found.append((value, line_words[i + 1]))
+                seen.add(i)
+                seen.add(i + 1)
+                continue
+        if looks_like_receipt_amount(texts[i]):
+            value = parse_receipt_amount(texts[i])
+            if value is not None:
+                found.append((value, word))
+                seen.add(i)
     return found
 
 
-def _positive_amounts_on_line_ids(
+def _amount_words_on_line(
+    line_words: list["ReceiptWord"],
+) -> list[tuple[float, "ReceiptWord"]]:
+    """Positive amounts on a line, including split currency+number tokens."""
+    return [
+        (amount, word)
+        for amount, word in _signed_amount_words_on_line(line_words)
+        if amount > 0
+    ]
+
+
+def _signed_amounts_on_line_ids(
     words: list["ReceiptWord"], line_ids: Collection[int]
 ) -> list[float]:
-    """Positive amounts printed on the given line ids (no y-band pairing)."""
+    """Signed amounts printed on the given line ids (no y-band pairing)."""
     wanted = {int(x) for x in line_ids}
     lines: dict[int, list["ReceiptWord"]] = {}
     for word in words:
@@ -478,7 +493,7 @@ def _positive_amounts_on_line_ids(
     amounts: list[float] = []
     for line_words in lines.values():
         line_words.sort(key=lambda w: getattr(w, "word_id", 0))
-        amounts.extend(amount for amount, _ in _amount_words_on_line(line_words))
+        amounts.extend(amount for amount, _ in _signed_amount_words_on_line(line_words))
     return amounts
 
 
@@ -718,29 +733,46 @@ def _apply_printed_total_fallback(
     totals: MonetaryTotals,
     words: list["ReceiptWord"],
     total_line_ids: Collection[int] | None = None,
+    grand_total_line_id: int | None = None,
 ) -> None:
     """Fill grand_total/subtotal from printed rows when labels gave none.
 
     A NEGATIVE label-derived total is a real figure, not a missing one:
     return receipts print trailing-minus amounts ("$16.25-") and
-    extract_amount now carries the sign through. The fallback only knows
-    positive printed amounts, so letting it run on negatives would
-    replace a refund's total with whatever stray positive figure sits in
-    the total row's y-band. Only None/zero totals fall back — except
-    when a TOTAL_LINE section is present and the label amount is not
-    printed on those lines (a VALID GRAND_TOTAL on the tax figure).
+    extract_amount now carries the sign through. The fallback only
+    overwrites with a positive TOTAL_LINE figure when the GRAND_TOTAL
+    label's line is not in that section (tax labeled as grand total).
     """
+    section_ids = {int(x) for x in total_line_ids} if total_line_ids else set()
+    section_printed: float | None = None
+    if section_ids:
+        section_amounts = _signed_amounts_on_line_ids(words, section_ids)
+        if section_amounts:
+            section_printed = max(section_amounts, key=lambda amount: (abs(amount), amount))
+
     printed = find_printed_grand_total(words, total_line_ids=total_line_ids)
-    if printed is not None:
+    fill = (
+        section_printed
+        if section_printed is not None and section_printed > 0
+        else printed
+    )
+
+    if totals.grand_total is not None and totals.grand_total < 0:
+        pass
+    elif fill is not None and fill > 0:
         if totals.grand_total is None or totals.grand_total == 0:
-            totals.grand_total = printed
-        elif total_line_ids:
-            on_section = _positive_amounts_on_line_ids(words, total_line_ids)
-            label_on_section = any(
-                abs(amount - totals.grand_total) < 0.005 for amount in on_section
+            totals.grand_total = fill
+        elif section_ids:
+            label_on_section = (
+                grand_total_line_id is not None
+                and int(grand_total_line_id) in section_ids
             )
-            if not label_on_section:
-                totals.grand_total = printed
+            if not label_on_section and section_printed is not None and section_printed > 0:
+                totals.grand_total = section_printed
+    if totals.subtotal is None or totals.subtotal == 0:
+        printed_sub = find_printed_subtotal(words)
+        if printed_sub is not None:
+            totals.subtotal = printed_sub
     if totals.subtotal is None or totals.subtotal == 0:
         printed_sub = find_printed_subtotal(words)
         if printed_sub is not None:
@@ -937,10 +969,15 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         }
 
         # Extract values from labels
-        totals, date, item_count = _extract_summary_fields(
+        totals, date, item_count, grand_total_line_id = _extract_summary_fields(
             word_labels, word_text_lookup
         )
-        _apply_printed_total_fallback(totals, words, total_line_ids=total_line_ids)
+        _apply_printed_total_fallback(
+            totals,
+            words,
+            total_line_ids=total_line_ids,
+            grand_total_line_id=grand_total_line_id,
+        )
 
         return cls(
             image_id=receipt.image_id,
@@ -1001,10 +1038,15 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         }
 
         # Extract values from labels
-        totals, date, item_count = _extract_summary_fields(
+        totals, date, item_count, grand_total_line_id = _extract_summary_fields(
             word_labels, word_text_lookup
         )
-        _apply_printed_total_fallback(totals, words, total_line_ids=total_line_ids)
+        _apply_printed_total_fallback(
+            totals,
+            words,
+            total_line_ids=total_line_ids,
+            grand_total_line_id=grand_total_line_id,
+        )
 
         return cls(
             image_id=image_id,

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -767,12 +767,16 @@ def _apply_printed_total_fallback(
                 grand_total_line_id is not None
                 and int(grand_total_line_id) in section_ids
             )
-            if not label_on_section and section_printed is not None and section_printed > 0:
+            if (
+                not label_on_section
+                and section_printed is not None
+                and section_printed > 0
+                and (
+                    totals.grand_total is None
+                    or section_printed > totals.grand_total
+                )
+            ):
                 totals.grand_total = section_printed
-    if totals.subtotal is None or totals.subtotal == 0:
-        printed_sub = find_printed_subtotal(words)
-        if printed_sub is not None:
-            totals.subtotal = printed_sub
     if totals.subtotal is None or totals.subtotal == 0:
         printed_sub = find_printed_subtotal(words)
         if printed_sub is not None:

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -72,9 +72,13 @@ class MonetaryTotals:
             if value is None:
                 continue
             if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError(f"{field_name} must be a finite number or None")
+                raise ValueError(
+                    f"{field_name} must be a finite number or None"
+                )
             if not isfinite(value):
-                raise ValueError(f"{field_name} must be a finite number or None")
+                raise ValueError(
+                    f"{field_name} must be a finite number or None"
+                )
             setattr(self, field_name, float(value))
 
     def to_dict(self) -> dict:
@@ -329,7 +333,7 @@ _LABEL_HANDLERS: dict[str, _HandlerFunc] = {
 def _extract_summary_fields(
     word_labels: list["ReceiptWordLabel"],
     word_text_lookup: dict[tuple[int, int], str],
-) -> tuple[MonetaryTotals, datetime | None, int]:
+) -> tuple[MonetaryTotals, datetime | None, int, int | None]:
     """Extract summary fields from word labels using dispatch pattern.
 
     Args:
@@ -414,7 +418,9 @@ def _word_height(word: "ReceiptWord") -> float:
 
 
 _CURRENCY_PREFIX_RE = re.compile(r"(?:[A-Za-z]{2,3})?\$+S?", re.I)
-_ISO_CURRENCY_PREFIX_RE = re.compile(r"(?:USD|EUR|GBP|CAD|AUD|JPY|MXN|CHF)S?", re.I)
+_ISO_CURRENCY_PREFIX_RE = re.compile(
+    r"(?:USD|EUR|GBP|CAD|AUD|JPY|MXN|CHF)S?", re.I
+)
 
 
 def _is_currency_prefix_token(text: str) -> bool:
@@ -493,7 +499,9 @@ def _signed_amounts_on_line_ids(
     amounts: list[float] = []
     for line_words in lines.values():
         line_words.sort(key=lambda w: getattr(w, "word_id", 0))
-        amounts.extend(amount for amount, _ in _signed_amount_words_on_line(line_words))
+        amounts.extend(
+            amount for amount, _ in _signed_amount_words_on_line(line_words)
+        )
     return amounts
 
 
@@ -517,7 +525,8 @@ def _is_grand_total_anchor(line_text: str) -> bool:
     (total + tips); anchoring on the tender row broke reconciliation.
     """
     return bool(
-        is_grand_total_line(line_text) and not TENDER_KEYWORD_RE.search(line_text)
+        is_grand_total_line(line_text)
+        and not TENDER_KEYWORD_RE.search(line_text)
     )
 
 
@@ -612,7 +621,9 @@ def find_printed_subtotal(words: list["ReceiptWord"]) -> float | None:
     anchored on subtotal rows and skipping total/tax/tender/savings
     rows when pairing across the y-band.
     """
-    return _find_anchored_amount(words, _is_subtotal_anchor, _is_subtotal_noise_line)
+    return _find_anchored_amount(
+        words, _is_subtotal_anchor, _is_subtotal_noise_line
+    )
 
 
 def find_printed_tax_words(
@@ -650,7 +661,9 @@ def find_printed_subtotal_words(
     words: list["ReceiptWord"],
 ) -> list[tuple[float, "ReceiptWord"]]:
     """Amount words anchored to a printed subtotal row."""
-    return _anchored_amount_words(words, _is_subtotal_anchor, _is_subtotal_noise_line)
+    return _anchored_amount_words(
+        words, _is_subtotal_anchor, _is_subtotal_noise_line
+    )
 
 
 def _find_anchored_amount(
@@ -686,7 +699,9 @@ def _anchored_amount_words(
         for line_id, line_words in lines.items()
     }
 
-    anchor_ids = [line_id for line_id, text in line_texts.items() if is_anchor(text)]
+    anchor_ids = [
+        line_id for line_id, text in line_texts.items() if is_anchor(text)
+    ]
     extra = {int(x) for x in (extra_anchor_ids or [])}
     for line_id in extra:
         if line_id not in lines or line_id in anchor_ids:
@@ -708,7 +723,9 @@ def _anchored_amount_words(
             continue
 
         # Pair with amount words in the anchor's y-band on other lines.
-        centers = [c for w in anchor_words if (c := _word_y_center(w)) is not None]
+        centers = [
+            c for w in anchor_words if (c := _word_y_center(w)) is not None
+        ]
         if not centers:
             continue
         anchor_y = sum(centers) / len(centers)
@@ -748,7 +765,9 @@ def _apply_printed_total_fallback(
     if section_ids:
         section_amounts = _signed_amounts_on_line_ids(words, section_ids)
         if section_amounts:
-            section_printed = max(section_amounts, key=lambda amount: (abs(amount), amount))
+            section_printed = max(
+                section_amounts, key=lambda amount: (abs(amount), amount)
+            )
 
     printed = find_printed_grand_total(words, total_line_ids=total_line_ids)
     fill = (
@@ -874,7 +893,9 @@ class ReceiptSummary(ReceiptIdentifierMixin):
     def __post_init__(self) -> None:
         """Validate identifiers and computed summary fields."""
         self._validate_receipt_identifiers()
-        if self.merchant_name is not None and not isinstance(self.merchant_name, str):
+        if self.merchant_name is not None and not isinstance(
+            self.merchant_name, str
+        ):
             raise ValueError("merchant_name must be a string or None")
         if self.date is not None and not isinstance(self.date, datetime):
             raise ValueError("date must be a datetime or None")
@@ -890,29 +911,41 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             and self.tender_class not in VALID_TENDER_CLASSES
         ):
             raise ValueError(
-                "tender_class must be one of " f"{sorted(VALID_TENDER_CLASSES)} or None"
+                "tender_class must be one of "
+                f"{sorted(VALID_TENDER_CLASSES)} or None"
             )
-        if self.card_network is not None and not isinstance(self.card_network, str):
+        if self.card_network is not None and not isinstance(
+            self.card_network, str
+        ):
             raise ValueError("card_network must be a string or None")
         if self.card_last4 is not None and (
-            not isinstance(self.card_last4, str) or not _LAST4_RE.match(self.card_last4)
+            not isinstance(self.card_last4, str)
+            or not _LAST4_RE.match(self.card_last4)
         ):
             raise ValueError("card_last4 must be a 4-digit string or None")
         if self.ledger is not None and self.ledger not in VALID_LEDGERS:
-            raise ValueError(f"ledger must be one of {sorted(VALID_LEDGERS)} or None")
+            raise ValueError(
+                f"ledger must be one of {sorted(VALID_LEDGERS)} or None"
+            )
         for field_name in ("bank_amount", "bank_match_confidence"):
             value = getattr(self, field_name)
             if value is None:
                 continue
             if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError(f"{field_name} must be a finite number or None")
+                raise ValueError(
+                    f"{field_name} must be a finite number or None"
+                )
             if not isfinite(value):
-                raise ValueError(f"{field_name} must be a finite number or None")
+                raise ValueError(
+                    f"{field_name} must be a finite number or None"
+                )
             setattr(self, field_name, float(value))
         if self.bank_match_confidence is not None and not (
             0.0 <= self.bank_match_confidence <= 1.0
         ):
-            raise ValueError("bank_match_confidence must be within [0, 1] or None")
+            raise ValueError(
+                "bank_match_confidence must be within [0, 1] or None"
+            )
 
     # Convenience properties for backwards compatibility
     @property
@@ -973,8 +1006,8 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         }
 
         # Extract values from labels
-        totals, date, item_count, grand_total_line_id = _extract_summary_fields(
-            word_labels, word_text_lookup
+        totals, date, item_count, grand_total_line_id = (
+            _extract_summary_fields(word_labels, word_text_lookup)
         )
         _apply_printed_total_fallback(
             totals,
@@ -1042,8 +1075,8 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         }
 
         # Extract values from labels
-        totals, date, item_count, grand_total_line_id = _extract_summary_fields(
-            word_labels, word_text_lookup
+        totals, date, item_count, grand_total_line_id = (
+            _extract_summary_fields(word_labels, word_text_lookup)
         )
         _apply_printed_total_fallback(
             totals,

--- a/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
+++ b/receipt_dynamo/receipt_dynamo/entities/receipt_summary.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass, field
 from datetime import datetime
 from math import isfinite
@@ -72,13 +72,9 @@ class MonetaryTotals:
             if value is None:
                 continue
             if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError(
-                    f"{field_name} must be a finite number or None"
-                )
+                raise ValueError(f"{field_name} must be a finite number or None")
             if not isfinite(value):
-                raise ValueError(
-                    f"{field_name} must be a finite number or None"
-                )
+                raise ValueError(f"{field_name} must be a finite number or None")
             setattr(self, field_name, float(value))
 
     def to_dict(self) -> dict:
@@ -423,6 +419,69 @@ def _positive_amount(text: str) -> float | None:
     return value
 
 
+_CURRENCY_PREFIX_RE = re.compile(r"(?:[A-Za-z]{2,3})?\$+S?", re.I)
+_ISO_CURRENCY_PREFIX_RE = re.compile(r"(?:USD|EUR|GBP|CAD|AUD|JPY|MXN|CHF)S?", re.I)
+
+
+def _is_currency_prefix_token(text: str) -> bool:
+    """OCR currency wrapper with no digits (``USD$``, ``USD$S``, ``US$``)."""
+    compact = re.sub(r"[\s:]", "", str(text).strip())
+    if not compact or re.search(r"\d", compact):
+        return False
+    return bool(
+        _CURRENCY_PREFIX_RE.fullmatch(compact)
+        or _ISO_CURRENCY_PREFIX_RE.fullmatch(compact)
+    )
+
+
+def _amount_words_on_line(
+    line_words: list["ReceiptWord"],
+) -> list[tuple[float, "ReceiptWord"]]:
+    """Positive amounts on a line, including split currency+number tokens.
+
+    Vision OCR often emits ``USD$S`` and ``7.43`` as adjacent words.
+    The numeric word is the one returned so callers can point a label
+    at the printed figure.
+    """
+    found: list[tuple[float, "ReceiptWord"]] = []
+    texts = [str(getattr(w, "text", "") or "") for w in line_words]
+    seen: set[int] = set()
+    for i, word in enumerate(line_words):
+        if i in seen:
+            continue
+        amount = _positive_amount(texts[i])
+        if amount is not None:
+            found.append((amount, word))
+            seen.add(i)
+            continue
+        if i + 1 < len(line_words) and _is_currency_prefix_token(texts[i]):
+            joined = f"{texts[i]} {texts[i + 1]}"
+            amount = _positive_amount(joined)
+            if amount is not None:
+                found.append((amount, line_words[i + 1]))
+                seen.add(i)
+                seen.add(i + 1)
+    return found
+
+
+def _positive_amounts_on_line_ids(
+    words: list["ReceiptWord"], line_ids: Collection[int]
+) -> list[float]:
+    """Positive amounts printed on the given line ids (no y-band pairing)."""
+    wanted = {int(x) for x in line_ids}
+    lines: dict[int, list["ReceiptWord"]] = {}
+    for word in words:
+        line_id = getattr(word, "line_id", None)
+        if line_id is None or int(line_id) not in wanted:
+            continue
+        lines.setdefault(int(line_id), []).append(word)
+    amounts: list[float] = []
+    for line_words in lines.values():
+        line_words.sort(key=lambda w: getattr(w, "word_id", 0))
+        amounts.extend(amount for amount, _ in _amount_words_on_line(line_words))
+    return amounts
+
+
 def _is_summary_noise_line(line_text: str) -> bool:
     """Return whether a line is a subtotal/tax/tender/non-payment row."""
     return bool(
@@ -443,8 +502,7 @@ def _is_grand_total_anchor(line_text: str) -> bool:
     (total + tips); anchoring on the tender row broke reconciliation.
     """
     return bool(
-        is_grand_total_line(line_text)
-        and not TENDER_KEYWORD_RE.search(line_text)
+        is_grand_total_line(line_text) and not TENDER_KEYWORD_RE.search(line_text)
     )
 
 
@@ -488,7 +546,11 @@ def _is_tax_noise_line(line_text: str) -> bool:
     )
 
 
-def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
+def find_printed_grand_total(
+    words: list["ReceiptWord"],
+    *,
+    total_line_ids: Collection[int] | None = None,
+) -> float | None:
     """Find the printed grand total from receipt words, without labels.
 
     Deterministic fallback for receipts whose GRAND_TOTAL labels are
@@ -502,20 +564,29 @@ def find_printed_grand_total(words: list["ReceiptWord"]) -> float | None:
     1. Find anchor lines whose joined text reads as a grand-total row
        (shared ``is_grand_total_line`` keywords) and is not a
        tender/settlement row (``_is_grand_total_anchor``).
-    2. Take amounts printed on the anchor line itself; otherwise pair the
-       anchor with amount words on other lines whose y-center falls in
-       the anchor's row band (skipping subtotal/tax/tender/savings rows).
-    3. Return the largest anchored amount, mirroring the GRAND_TOTAL
+    2. When the caller has already assigned a TOTAL_LINE section, those
+       line ids are extra anchors (post-join, not a new section finder).
+       A TOTAL_LINE row that is only ``USD$S 7.43`` still counts even
+       when the "Total:" keyword OCR-failed.
+    3. Take amounts printed on the anchor line itself, including split
+       currency-prefix + figure tokens; otherwise pair the anchor with
+       amount words on other lines whose y-center falls in the anchor's
+       row band (skipping subtotal/tax/tender/savings rows).
+    4. Return the largest anchored amount, mirroring the GRAND_TOTAL
        label handler's largest-value semantics.
 
     Args:
         words: ReceiptWord records (text + normalized bounding boxes).
+        total_line_ids: Optional TOTAL_LINE section line ids.
 
     Returns:
         The printed grand total, or None when no anchored amount exists.
     """
     return _find_anchored_amount(
-        words, _is_grand_total_anchor, _is_summary_noise_line
+        words,
+        _is_grand_total_anchor,
+        _is_summary_noise_line,
+        extra_anchor_ids=total_line_ids,
     )
 
 
@@ -526,9 +597,7 @@ def find_printed_subtotal(words: list["ReceiptWord"]) -> float | None:
     anchored on subtotal rows and skipping total/tax/tender/savings
     rows when pairing across the y-band.
     """
-    return _find_anchored_amount(
-        words, _is_subtotal_anchor, _is_subtotal_noise_line
-    )
+    return _find_anchored_amount(words, _is_subtotal_anchor, _is_subtotal_noise_line)
 
 
 def find_printed_tax_words(
@@ -545,6 +614,8 @@ def find_printed_tax_words(
 
 def find_printed_grand_total_words(
     words: list["ReceiptWord"],
+    *,
+    total_line_ids: Collection[int] | None = None,
 ) -> list[tuple[float, "ReceiptWord"]]:
     """Amount words anchored to a printed grand-total row.
 
@@ -553,7 +624,10 @@ def find_printed_grand_total_words(
     the printed figure need the word it was printed on.
     """
     return _anchored_amount_words(
-        words, _is_grand_total_anchor, _is_summary_noise_line
+        words,
+        _is_grand_total_anchor,
+        _is_summary_noise_line,
+        extra_anchor_ids=total_line_ids,
     )
 
 
@@ -561,18 +635,19 @@ def find_printed_subtotal_words(
     words: list["ReceiptWord"],
 ) -> list[tuple[float, "ReceiptWord"]]:
     """Amount words anchored to a printed subtotal row."""
-    return _anchored_amount_words(
-        words, _is_subtotal_anchor, _is_subtotal_noise_line
-    )
+    return _anchored_amount_words(words, _is_subtotal_anchor, _is_subtotal_noise_line)
 
 
 def _find_anchored_amount(
     words: list["ReceiptWord"],
     is_anchor: Callable[[str], bool],
     is_noise: Callable[[str], bool],
+    extra_anchor_ids: Collection[int] | None = None,
 ) -> float | None:
     """Largest amount printed on (or row-banded with) an anchor line."""
-    anchored = _anchored_amount_words(words, is_anchor, is_noise)
+    anchored = _anchored_amount_words(
+        words, is_anchor, is_noise, extra_anchor_ids=extra_anchor_ids
+    )
     return max(amount for amount, _ in anchored) if anchored else None
 
 
@@ -580,6 +655,7 @@ def _anchored_amount_words(
     words: list["ReceiptWord"],
     is_anchor: Callable[[str], bool],
     is_noise: Callable[[str], bool],
+    extra_anchor_ids: Collection[int] | None = None,
 ) -> list[tuple[float, "ReceiptWord"]]:
     """Amounts printed on (or row-banded with) an anchor line, with words."""
     lines: dict[int, list["ReceiptWord"]] = {}
@@ -595,9 +671,14 @@ def _anchored_amount_words(
         for line_id, line_words in lines.items()
     }
 
-    anchor_ids = [
-        line_id for line_id, text in line_texts.items() if is_anchor(text)
-    ]
+    anchor_ids = [line_id for line_id, text in line_texts.items() if is_anchor(text)]
+    extra = {int(x) for x in (extra_anchor_ids or [])}
+    for line_id in extra:
+        if line_id not in lines or line_id in anchor_ids:
+            continue
+        if is_noise(line_texts[line_id]):
+            continue
+        anchor_ids.append(line_id)
     if not anchor_ids:
         return []
 
@@ -606,20 +687,13 @@ def _anchored_amount_words(
         anchor_words = lines[anchor_id]
 
         # Amounts printed on the anchor line itself win outright.
-        same_line = [
-            (amount, w)
-            for w in anchor_words
-            if (amount := _positive_amount(str(getattr(w, "text", ""))))
-            is not None
-        ]
+        same_line = _amount_words_on_line(anchor_words)
         if same_line:
             anchored.extend(same_line)
             continue
 
         # Pair with amount words in the anchor's y-band on other lines.
-        centers = [
-            c for w in anchor_words if (c := _word_y_center(w)) is not None
-        ]
+        centers = [c for w in anchor_words if (c := _word_y_center(w)) is not None]
         if not centers:
             continue
         anchor_y = sum(centers) / len(centers)
@@ -631,19 +705,19 @@ def _anchored_amount_words(
                 continue
             if is_noise(line_texts[line_id]):
                 continue
-            for w in line_words:
+            for amount, w in _amount_words_on_line(line_words):
                 center = _word_y_center(w)
                 if center is None or abs(center - anchor_y) > band:
                     continue
-                amount = _positive_amount(str(getattr(w, "text", "")))
-                if amount is not None:
-                    anchored.append((amount, w))
+                anchored.append((amount, w))
 
     return anchored
 
 
 def _apply_printed_total_fallback(
-    totals: MonetaryTotals, words: list["ReceiptWord"]
+    totals: MonetaryTotals,
+    words: list["ReceiptWord"],
+    total_line_ids: Collection[int] | None = None,
 ) -> None:
     """Fill grand_total/subtotal from printed rows when labels gave none.
 
@@ -652,16 +726,25 @@ def _apply_printed_total_fallback(
     extract_amount now carries the sign through. The fallback only knows
     positive printed amounts, so letting it run on negatives would
     replace a refund's total with whatever stray positive figure sits in
-    the total row's y-band. Only None/zero totals fall back.
+    the total row's y-band. Only None/zero totals fall back — except
+    when a TOTAL_LINE section is present and the label amount is not
+    printed on those lines (a VALID GRAND_TOTAL on the tax figure).
     """
-    if totals.grand_total is None or totals.grand_total == 0:
-        printed = find_printed_grand_total(words)
-        if printed is not None:
+    printed = find_printed_grand_total(words, total_line_ids=total_line_ids)
+    if printed is not None:
+        if totals.grand_total is None or totals.grand_total == 0:
             totals.grand_total = printed
+        elif total_line_ids:
+            on_section = _positive_amounts_on_line_ids(words, total_line_ids)
+            label_on_section = any(
+                abs(amount - totals.grand_total) < 0.005 for amount in on_section
+            )
+            if not label_on_section:
+                totals.grand_total = printed
     if totals.subtotal is None or totals.subtotal == 0:
-        printed = find_printed_subtotal(words)
-        if printed is not None:
-            totals.subtotal = printed
+        printed_sub = find_printed_subtotal(words)
+        if printed_sub is not None:
+            totals.subtotal = printed_sub
 
 
 # =============================================================================
@@ -755,9 +838,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
     def __post_init__(self) -> None:
         """Validate identifiers and computed summary fields."""
         self._validate_receipt_identifiers()
-        if self.merchant_name is not None and not isinstance(
-            self.merchant_name, str
-        ):
+        if self.merchant_name is not None and not isinstance(self.merchant_name, str):
             raise ValueError("merchant_name must be a string or None")
         if self.date is not None and not isinstance(self.date, datetime):
             raise ValueError("date must be a datetime or None")
@@ -773,41 +854,29 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             and self.tender_class not in VALID_TENDER_CLASSES
         ):
             raise ValueError(
-                "tender_class must be one of "
-                f"{sorted(VALID_TENDER_CLASSES)} or None"
+                "tender_class must be one of " f"{sorted(VALID_TENDER_CLASSES)} or None"
             )
-        if self.card_network is not None and not isinstance(
-            self.card_network, str
-        ):
+        if self.card_network is not None and not isinstance(self.card_network, str):
             raise ValueError("card_network must be a string or None")
         if self.card_last4 is not None and (
-            not isinstance(self.card_last4, str)
-            or not _LAST4_RE.match(self.card_last4)
+            not isinstance(self.card_last4, str) or not _LAST4_RE.match(self.card_last4)
         ):
             raise ValueError("card_last4 must be a 4-digit string or None")
         if self.ledger is not None and self.ledger not in VALID_LEDGERS:
-            raise ValueError(
-                f"ledger must be one of {sorted(VALID_LEDGERS)} or None"
-            )
+            raise ValueError(f"ledger must be one of {sorted(VALID_LEDGERS)} or None")
         for field_name in ("bank_amount", "bank_match_confidence"):
             value = getattr(self, field_name)
             if value is None:
                 continue
             if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError(
-                    f"{field_name} must be a finite number or None"
-                )
+                raise ValueError(f"{field_name} must be a finite number or None")
             if not isfinite(value):
-                raise ValueError(
-                    f"{field_name} must be a finite number or None"
-                )
+                raise ValueError(f"{field_name} must be a finite number or None")
             setattr(self, field_name, float(value))
         if self.bank_match_confidence is not None and not (
             0.0 <= self.bank_match_confidence <= 1.0
         ):
-            raise ValueError(
-                "bank_match_confidence must be within [0, 1] or None"
-            )
+            raise ValueError("bank_match_confidence must be within [0, 1] or None")
 
     # Convenience properties for backwards compatibility
     @property
@@ -844,6 +913,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         words: list["ReceiptWord"],
         *,
         line_item_count: int | None = None,
+        total_line_ids: Collection[int] | None = None,
     ) -> "ReceiptSummary":
         """Compute a summary from receipt data.
 
@@ -855,6 +925,8 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             line_item_count: Number of ``ReceiptLineItem`` rows the
                 receipt currently holds. Preferred over the LINE_TOTAL
                 label count when non-zero (see :func:`resolve_item_count`).
+            total_line_ids: Optional TOTAL_LINE section line ids used as
+                extra printed-total anchors.
 
         Returns:
             A ReceiptSummary with computed fields.
@@ -868,7 +940,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         totals, date, item_count = _extract_summary_fields(
             word_labels, word_text_lookup
         )
-        _apply_printed_total_fallback(totals, words)
+        _apply_printed_total_fallback(totals, words, total_line_ids=total_line_ids)
 
         return cls(
             image_id=receipt.image_id,
@@ -895,6 +967,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         bank_amount: float | None = None,
         bank_match_confidence: float | None = None,
         line_item_count: int | None = None,
+        total_line_ids: Collection[int] | None = None,
     ) -> "ReceiptSummary":
         """Compute a summary from word labels and words directly.
 
@@ -916,6 +989,8 @@ class ReceiptSummary(ReceiptIdentifierMixin):
             line_item_count: Number of ``ReceiptLineItem`` rows the
                 receipt currently holds. Preferred over the LINE_TOTAL
                 label count when non-zero (see :func:`resolve_item_count`).
+            total_line_ids: Optional TOTAL_LINE section line ids used as
+                extra printed-total anchors.
 
         Returns:
             A ReceiptSummary with computed fields.
@@ -929,7 +1004,7 @@ class ReceiptSummary(ReceiptIdentifierMixin):
         totals, date, item_count = _extract_summary_fields(
             word_labels, word_text_lookup
         )
-        _apply_printed_total_fallback(totals, words)
+        _apply_printed_total_fallback(totals, words, total_line_ids=total_line_ids)
 
         return cls(
             image_id=image_id,

--- a/receipt_dynamo/tests/unit/test_amounts.py
+++ b/receipt_dynamo/tests/unit/test_amounts.py
@@ -23,7 +23,21 @@ def test_parse_negative_accounting_amount():
     assert parse_receipt_amount("8.82-") == -8.82
 
 
+def test_parse_ocr_mangled_currency_prefix():
+    assert parse_receipt_amount("USD$S 7.43") == 7.43
+    assert parse_receipt_amount("USD$S7.43") == 7.43
+    assert parse_receipt_amount("USD$ 42.54") == 42.54
+    assert parse_receipt_amount("USD$S") is None
+
+
 def test_looks_like_receipt_amount_excludes_plain_integers():
     assert looks_like_receipt_amount("$8,82")
     assert looks_like_receipt_amount("8,82")
     assert not looks_like_receipt_amount("123")
+
+
+def test_looks_like_receipt_amount_rejects_currency_prefix_without_digits():
+    assert not looks_like_receipt_amount("USD$S")
+    assert not looks_like_receipt_amount("USD$")
+    assert looks_like_receipt_amount("USD$S 7.43")
+    assert not looks_like_receipt_amount("USDS 7.43")

--- a/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
@@ -415,3 +415,44 @@ def test_void_balance_due_does_not_invent_a_positive_total():
         _word(15, 1, "6.00", 0.5029, x=0.760),
     ]
     assert find_printed_grand_total(words, total_line_ids=[12, 14]) is None
+
+
+def test_negative_label_survives_total_line_with_stray_positive():
+    # Codex HIGH: TOTAL_LINE extra anchors used to drop negatives, then
+    # overwrite a labeled -$6.00 with CHANGE $6.00.
+    words = [
+        _word(12, 1, "BALANCE", 0.5407, x=0.112),
+        _word(12, 2, "DUE", 0.5407, x=0.281),
+        _word(14, 1, "-", 0.5327, x=0.700),
+        _word(14, 2, "6.00", 0.5327, x=0.731),
+        _word(13, 1, "CHANGE", 0.5131, x=0.112),
+        _word(15, 1, "6.00", 0.5029, x=0.760),
+    ]
+    totals = MonetaryTotals(grand_total=-6.00)
+    _apply_printed_total_fallback(
+        totals, words, total_line_ids=[12, 14, 15]
+    )
+    assert totals.grand_total == pytest.approx(-6.00)
+
+
+def test_total_line_override_uses_label_line_id_not_numeric_match():
+    # Codex MEDIUM: tax 0.65 restated on TOTAL_LINE must not make an
+    # off-section GRAND_TOTAL label look section-backed.
+    words = [
+        _word(47, 1, "TAX", 0.5237, x=0.062),
+        _word(54, 1, "0.65", 0.5228, x=0.800),
+        _word(49, 1, "BALANCE", 0.5032, x=0.154),
+        _word(49, 2, "DUE", 0.5032, x=0.334),
+        _word(55, 1, "25.85", 0.5028, x=0.775),
+        _word(56, 1, "0.65", 0.5028, x=0.900),
+    ]
+    labels = [_label(54, 1, "GRAND_TOTAL", ValidationStatus.VALID.value)]
+    summary = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name=None,
+        word_labels=labels,
+        words=words,
+        total_line_ids=[49, 55, 56],
+    )
+    assert summary.grand_total == pytest.approx(25.85)

--- a/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
@@ -456,3 +456,25 @@ def test_total_line_override_uses_label_line_id_not_numeric_match():
         total_line_ids=[49, 55, 56],
     )
     assert summary.grand_total == pytest.approx(25.85)
+
+
+def test_smaller_total_line_does_not_clobber_a_larger_label():
+    # d076611b r2: stored GT 10.99 already matches items; TOTAL_LINE on
+    # this crop is a smaller card-slip figure. Do not replace.
+    words = [
+        _word(10, 1, "TOTAL", 0.50, x=0.10),
+        _word(11, 1, "10.99", 0.50, x=0.80),
+        _word(20, 1, "BALANCE", 0.30, x=0.10),
+        _word(20, 2, "DUE", 0.30, x=0.30),
+        _word(21, 1, "6.20", 0.30, x=0.80),
+    ]
+    labels = [_label(11, 1, "GRAND_TOTAL", ValidationStatus.VALID.value)]
+    summary = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=2,
+        merchant_name=None,
+        word_labels=labels,
+        words=words,
+        total_line_ids=[20, 21],
+    )
+    assert summary.grand_total == pytest.approx(10.99)

--- a/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
@@ -50,9 +50,7 @@ def _word(
     )
 
 
-def _label(
-    line_id: int, word_id: int, label: str, status: str
-) -> ReceiptWordLabel:
+def _label(line_id: int, word_id: int, label: str, status: str) -> ReceiptWordLabel:
     return ReceiptWordLabel(
         image_id=IMAGE_ID,
         receipt_id=1,
@@ -323,3 +321,97 @@ def test_moody_fallback_fills_grand_total_and_subtotal():
     # the $20 bowl reconciles against baseline 20.00.
     assert totals.grand_total == 21.45
     assert totals.subtotal == 20.00
+
+
+# ---------------------------------------------------------------------------
+# OCR-mangled currency tokens + TOTAL_LINE extra anchors.
+# 383a90d8 r2 prints "Total:" / "USD$S 7.43" (Vision doubled the $ into
+# a trailing S). 37c9f558 r1 has a VALID GRAND_TOTAL on the tax figure
+# 0.65 while TOTAL_LINE carries 25.85. Bottle-return voids print a
+# negative BALANCE DUE and must not invent a positive total.
+# ---------------------------------------------------------------------------
+
+
+def _sprouts_383a90d8_words() -> list[SimpleNamespace]:
+    """Card-slip + TOTAL_LINE of dev receipt 383a90d8:2 (grand total 7.43)."""
+    return [
+        _word(29, 1, "Total:", 0.7950, x=0.020),
+        _word(30, 1, "USD$S", 0.7923, x=0.763),
+        _word(30, 2, "7.43", 0.7923, x=0.881),
+        _word(47, 1, "BALANCE", 0.5075, x=0.125),
+        _word(47, 2, "DUE", 0.5078, x=0.314),
+        _word(57, 1, "7.43", 0.5065, x=0.787),
+        _word(58, 1, "$7.43", 0.4940, x=0.770),
+        _word(51, 1, "CHANGE", 0.4580, x=0.125),
+        _word(60, 1, "0.00", 0.4564, x=0.796),
+    ]
+
+
+def test_split_usds_prefix_pairs_with_amount_on_same_line():
+    assert find_printed_grand_total(_sprouts_383a90d8_words()) == 7.43
+
+
+def test_glued_usds_token_parses_as_printed_total():
+    words = [
+        _word(1, 1, "Total:", 0.7950, x=0.020),
+        _word(2, 1, "USD$S 7.43", 0.7923, x=0.763),
+    ]
+    assert find_printed_grand_total(words) == 7.43
+
+
+def test_total_line_ids_anchor_without_total_keyword():
+    # Keyword OCR dropped "Total:"; the section finder still tagged the
+    # amount row as TOTAL_LINE. Extra anchors recover the figure.
+    words = [
+        _word(30, 1, "USD$S", 0.7923, x=0.763),
+        _word(30, 2, "7.43", 0.7923, x=0.881),
+        _word(43, 1, "CANADIAN", 0.5689, x=0.100),
+        _word(44, 1, "$17.99/", 0.5671, x=0.363),
+    ]
+    assert find_printed_grand_total(words) is None
+    assert find_printed_grand_total(words, total_line_ids=[30]) == 7.43
+
+
+def test_total_line_overrides_grand_total_label_off_section():
+    # 37c9f558: VALID GRAND_TOTAL on tax 0.65; TOTAL_LINE is 25.85.
+    words = [
+        _word(47, 1, "TAX", 0.5237, x=0.062),
+        _word(54, 1, "0.65", 0.5228, x=0.800),
+        _word(49, 1, "BALANCE", 0.5032, x=0.154),
+        _word(49, 2, "DUE", 0.5032, x=0.334),
+        _word(55, 1, "25.85", 0.5028, x=0.775),
+        _word(56, 1, "$25.85", 0.4921, x=0.754),
+    ]
+    labels = [_label(54, 1, "GRAND_TOTAL", ValidationStatus.VALID.value)]
+
+    without_section = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name=None,
+        word_labels=labels,
+        words=words,
+    )
+    assert without_section.grand_total == 0.65
+
+    with_section = ReceiptSummary.from_word_labels_and_words(
+        image_id=IMAGE_ID,
+        receipt_id=1,
+        merchant_name=None,
+        word_labels=labels,
+        words=words,
+        total_line_ids=[49, 55],
+    )
+    assert with_section.grand_total == 25.85
+
+
+def test_void_balance_due_does_not_invent_a_positive_total():
+    # 8e6faa9a / bd770f76: bottle-return BALANCE DUE is negative; CHANGE
+    # restates the cash given back. Do not mint a positive grand total.
+    words = [
+        _word(12, 1, "BALANCE", 0.5407, x=0.112),
+        _word(12, 2, "DUE", 0.5407, x=0.281),
+        _word(14, 1, "-6.00", 0.5327, x=0.731),
+        _word(13, 1, "CHANGE", 0.5131, x=0.112),
+        _word(15, 1, "6.00", 0.5029, x=0.760),
+    ]
+    assert find_printed_grand_total(words, total_line_ids=[12, 14]) is None

--- a/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
+++ b/receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py
@@ -50,7 +50,9 @@ def _word(
     )
 
 
-def _label(line_id: int, word_id: int, label: str, status: str) -> ReceiptWordLabel:
+def _label(
+    line_id: int, word_id: int, label: str, status: str
+) -> ReceiptWordLabel:
     return ReceiptWordLabel(
         image_id=IMAGE_ID,
         receipt_id=1,
@@ -429,9 +431,7 @@ def test_negative_label_survives_total_line_with_stray_positive():
         _word(15, 1, "6.00", 0.5029, x=0.760),
     ]
     totals = MonetaryTotals(grand_total=-6.00)
-    _apply_printed_total_fallback(
-        totals, words, total_line_ids=[12, 14, 15]
-    )
+    _apply_printed_total_fallback(totals, words, total_line_ids=[12, 14, 15])
     assert totals.grand_total == pytest.approx(-6.00)
 
 


### PR DESCRIPTION
## Summary
- Recovers usable printed grand totals from TOTAL_LINE / grand-total furniture when OCR mangles the currency token (`USD$S 7.43`, split `USD$S` + `7.43`) or a VALID `GRAND_TOTAL` label lands on the tax figure.
- Pipeline fit: image → Mac Vision OCR → LayoutLM furniture → section assignment (`TOTAL_LINE` vs `PAYMENT`) → `ReceiptSummary` printed-total fallback → stream recomputes line items so `extract_items` + `constrain_items_to_baseline` have a number. Does not touch ITEMS decode (`geometry.py` / `blocks.py` / Swift).
- Merchant-agnostic: no Sprouts `if merchant`, no new closed vocab. `parse_receipt_amount` already strips letters/`$`; pairing now joins a currency-prefix token to the adjacent figure, and TOTAL_LINE line ids are extra anchors when the caller has sections (summary updater already loads them).

Stacked on #1412 (`feat/baseline-constraint-decode` @ `440edff60`).

## Of the 5 Sprouts `no-baseline` receipts (187 GSI1 on `ReceiptsTable-dc5be22`)
| Receipt | Printed on paper | Result |
|---|---|---|
| `37c9f558` r1 | TOTAL_LINE `25.85`; label was tax `0.65` | **Recovered** → `near` (27.05 vs 25.85) |
| `383a90d8` r2 | `USD$S 7.43` / BALANCE DUE `7.43` | Printed total already stored; still `no-baseline` because items include a `$17.99/` unit-price (decode, not summary) |
| `2050f988` r1 | BALANCE DUE `19.97` | Printed total already stored; items overwhelm 3× baseline (discount/zone, not summary) |
| `8e6faa9a` r1 | BALANCE DUE **`-6.00`** (bottle return) | Still no positive total — not invented |
| `bd770f76` r1 | BALANCE DUE **`-3.00`** (bottle return) | Still no positive total — not invented |

**1 of 5 recovered.** Two already had a printed total (constraint cannot help until decode/zone PRs). Two are voids with a negative BALANCE DUE and no positive figure on the paper.

## Test plan
- [x] `pytest receipt_dynamo/tests/unit/test_receipt_summary_printed_total.py receipt_dynamo/tests/unit/test_amounts.py receipt_upload/tests/test_reconcile_baseline.py receipt_upload/tests/test_baseline_constraint.py receipt_upload/tests/test_line_item_golden_regression.py tests/test_receipt_summary_updater_tender.py`
- [x] Dev Dynamo read of the 5 no-baseline Sprouts tickets (no writes)
- [ ] Summary updater recompute on `37c9f558` after merge (stream will pick up TOTAL_LINE override)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt total detection when currency symbols are split or distorted by OCR.
  * Added support for negative amounts, refunds, and standalone minus signs.
  * Improved selection of printed totals using receipt section information.
  * Prevented invalid currency-only text from being interpreted as an amount.
  * Improved fallback handling for mismatched or negative totals.

* **Tests**
  * Added regression coverage for OCR variations, total-line matching, and negative balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->