### PR TITLE
fix(line-items): gated join of shattered price fragments

### DIFF
--- a/.cursor/skills/sprouts-line-item-stack/SKILL.md
+++ b/.cursor/skills/sprouts-line-item-stack/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: sprouts-line-item-stack
+description: >-
+  Stacked line-item decode PRs toward Sprouts match, then remaining-error
+  EDA and other-merchant uplift. Use when stacking receipt decode fixes,
+  running Sprouts A/B evals, investigating remaining mismatches/nears,
+  or measuring lift on other merchants after a geometry/summary layer.
+---
+
+# Sprouts line-item stack
+
+Continue the **constraint → pairing → fragment join → qty-echo/ITEMS-tail → zone-gap** stack. Do not chase 187/187: bottle-return refunds stay no-baseline.
+
+## Pipeline (do not fork)
+
+`Image → Mac Vision OCR → LayoutLM furniture (not product labels) → sections → extract_items / decode_band_blocks → persist → stream recompute on summary.`
+
+Cloud recompute is canonical. Mac first-pass without a summary is a no-op for constraint.
+
+## Hard constraints
+
+- No LayoutLM **product** labels into the section finder.
+- No merchant `if`s / Sprouts regexes in `geometry.py`.
+- No new Dynamo discount schema (`is_discount` + negative `price` already exist).
+- Never mint a missing column price (two names + one amount stay one item).
+- Do not lower golden floors.
+- Do not run `pulumi`. Never write prod `ReceiptsTable-d7ff76a`. Dev evals: `ReceiptsTable-dc5be22` read-only.
+- Never commit to `main`. Never force-push.
+
+## Stacking
+
+Geometry/Swift decode layers stack on **pairing** (`feat/two-column-pairing`, #1416), not on TOTAL_LINE (#1415). #1415 is `receipt_dynamo` / summary and stays a sibling.
+
+1. Create a worktree from the previous layer tip.
+2. One mechanism per PR. Smallest safe change. Tests for the fixture receipts.
+3. `gh pr create --base <previous-layer-branch>`. Then `gh stack link` onto the geometry stack.
+4. PYTHONPATH must point at the **worktree** packages; the venv editable install is `/Users/tnorlund/Portfolio`.
+
+```bash
+PYTHONPATH="$WT/receipt_upload:$WT/receipt_dynamo" \
+  /Users/tnorlund/Portfolio/.venv/bin/pytest \
+  receipt_upload/tests/test_baseline_constraint.py \
+  receipt_upload/tests/test_two_column_pairing.py \
+  receipt_upload/tests/test_line_item_golden_regression.py
+```
+
+Format only files you touch.
+
+## Eval
+
+Reuse `/tmp/sprouts_stack_eval.py` (pairing `receipt_upload` + baseline-recovery `receipt_dynamo` for TOTAL_LINE). Unset `HTTP_PROXY`. After each layer, report Sprouts match/near/mismatch/no-baseline vs 168/187 (89.8%) full stack.
+
+Then sweep **other merchants** the same way (GSI1 by merchant, same decode path). Report match-rate delta vs main-style (no constrain/split) and vs current stack. A layer that regresses another merchant does not ship.
+
+## Remaining error loop
+
+After a layer lands, spawn EDA subagents on remaining Sprouts misses (mismatch / near / no-baseline). Cluster mechanisms. Next PR is the smallest generic decode/summary fix, not a merchant special case. Leave as near: CRV-vs-tax pennies, missing OCR amounts, refunds.
+
+Known unrecoverable without new OCR: cropped `2c9b770c` (−$9.99), `dbc78ee2` RAW CREAM (no amount token), digit/glyph misreads (`7.99`→`1.99`) — those are re-OCR on the **reconcile baseline**, not `subtotal`-only.
+
+## Do not
+
+Ungated `merge_price_fragments` (Costco `5,`+`90` → 5.90). Treat `1.` or `)` as a decimal. Mint footer coupons as line discounts. Feed product labels into sections.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,10 @@ this file only covers environment mechanics.
 - Do not run `pulumi` commands; deploys are CI-driven (and a local `pulumi up` can lock the
   account-wide stack).
 - Don't commit screenshots, logs, or `dev.*` scratch scripts you didn't author.
+
+## Line-item decode stack
+
+Sprouts match is stacked geometry PRs (constraint → pairing → fragment join →
+qty-echo / ITEMS tail → zone-gap), then remaining-error EDA plus other-merchant
+uplift. Follow `.cursor/skills/sprouts-line-item-stack/SKILL.md`. Do not chase
+187/187; bottle-return refunds stay no-baseline.

--- a/infra/receipt_line_item_updater/line_item_processor.py
+++ b/infra/receipt_line_item_updater/line_item_processor.py
@@ -268,7 +268,9 @@ def update_receipt_line_items(
 
     line_ids = {int(x) for x in (items_section.line_ids or [])}
 
-    items, collapsed = extract_items(word_dicts, line_ids, summary=summary_dict)
+    items, collapsed = extract_items(
+        word_dicts, line_ids, summary=summary_dict
+    )
 
     recon = reconcile_extracted_items(items, summary_dict)
     status = recon.status
@@ -277,7 +279,9 @@ def update_receipt_line_items(
     entities = []
     for idx, it in enumerate(items):
         name = it.get("name") or ""
-        quality = "low" if it.get("name_quality") == "low" or not name else "ok"
+        quality = (
+            "low" if it.get("name_quality") == "low" or not name else "ok"
+        )
         entities.append(
             ReceiptLineItem(
                 receipt_id=receipt_id,
@@ -540,7 +544,9 @@ def _maybe_extend_items_section(
     """Persist a reconciliation-verified adjacent-row ITEMS extension."""
 
     try:
-        rows = dynamo_client.get_receipt_rows_from_receipt(image_id, receipt_id)
+        rows = dynamo_client.get_receipt_rows_from_receipt(
+            image_id, receipt_id
+        )
     except EntityNotFoundError:
         rows = []
     proposal = propose_items_boundary_extension(
@@ -873,7 +879,8 @@ def _maybe_trigger_line_item_refine(
         # receipt_dynamo's `assert_valid_uuid` (its regex accepts
         # version 4 or 5 with the RFC-4122 variant).
         figures = ":".join(
-            _claim_figure(refine_summary[key]) for key in REFINE_SUMMARY_FIGURES
+            _claim_figure(refine_summary[key])
+            for key in REFINE_SUMMARY_FIGURES
         )
         job_id = str(
             uuid.uuid5(

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -326,17 +326,38 @@ def decode_blocks(ocr_receipt: dict, priors: dict) -> list[dict]:
     return items
 
 
+def _join_price_fragment_pair(left: str, right: str) -> str | None:
+    """Join two OCR tokens into a two-decimal amount, or None.
+
+    Shapes: ``5.``+``79`` / ``5,``+``90`` (digits plus a separator, then
+    two cents digits) and ``5``+``.99`` (bare dollars then a leading-dot
+    cents token). ``)`` is not a decimal; ``5``+``1.``+``99`` is not a
+    special case -- ``1.``+``99`` may join to 1.99, and the receipt-level
+    gate in ``extract_items`` must reject that unless the printed total
+    then matches exactly.
+    """
+    if re.fullmatch(r"\$?\d{1,4}[.,]", left) and re.fullmatch(r"\d{2}", right):
+        return left.replace(",", ".") + right
+    if re.fullmatch(r"\$?\d{1,4}", left) and re.fullmatch(r"\.\d{2}", right):
+        return left + right
+    return None
+
+
 def merge_price_fragments(words: list[dict]) -> list[dict]:
     """Concatenate OCR-shattered price fragments within a band.
 
     Vision splits some prices into adjacent tokens -- "1." + "99" for 1.99
-    (Costco), "5," + "90" (comma for period). Textract read the same
-    pixels whole, which is a large part of its 90% vs our 85% recall.
-    Merge an x-adjacent pair when the left token is digits ending in a
-    separator and the right is exactly two digits, yielding a valid
-    amount. Digit MISREADS (4.89 read as 1.89) are left alone: no
-    geometry can recover a digit OCR never produced -- that class is the
-    re-OCR trigger's job.
+    (Costco), "5," + "90" (comma for period), "5" + ".99" (bare dollars
+    then a cents token). Textract read the same pixels whole, which is a
+    large part of its 90% vs our 85% recall. Merge an x-adjacent pair
+    when the tokens form one of those shapes and the gap is under 0.08,
+    yielding a valid amount. Digit MISREADS (4.89 read as 1.89) are left
+    alone: no geometry can recover a digit OCR never produced -- that
+    class is the re-OCR trigger's job.
+
+    Ungated use in ``_zone_bands`` is forbidden: Costco ``5,``+``90``
+    becomes a plausible 5.90 against truth 5.99. ``extract_items`` trials
+    this merge and keeps it only on an exact printed-total match.
     """
     if len(words) < 2:
         return words
@@ -348,13 +369,14 @@ def merge_price_fragments(words: list[dict]) -> list[dict]:
         if i + 1 < len(ws):
             nxt = ws[i + 1]
             gap = nxt["x"] - w["x"]
-            if (
-                re.fullmatch(r"\$?\d{1,4}[.,]", w["text"])
-                and re.fullmatch(r"\d{2}", nxt["text"])
-                and 0 <= gap < 0.08
-            ):
+            joined = (
+                _join_price_fragment_pair(w["text"], nxt["text"])
+                if 0 <= gap < 0.08
+                else None
+            )
+            if joined is not None:
                 merged = dict(w)
-                merged["text"] = w["text"].replace(",", ".") + nxt["text"]
+                merged["text"] = joined
                 out.append(merged)
                 i += 2
                 continue
@@ -406,8 +428,8 @@ def _zone_bands(ocr_receipt: dict) -> list[dict]:
         # merge_price_fragments is deliberately NOT applied here: run
         # unconditionally it manufactured a plausible-but-wrong 5.90 from
         # "5,"+"90" (truth 5.99 -- shattered AND digit-misread) and failed
-        # Costco's precision floor. Fragment reconstruction is a REPAIR
-        # action for the reconciliation-triggered path, alongside re-OCR.
+        # Costco's precision floor. extract_items trials the merge after
+        # constrain and keeps it only when the printed total then matches.
         text = " ".join(w["text"] for w in band)
         out.append(
             {

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -1005,6 +1005,36 @@ def _name_is_real(name: str) -> bool:
     return len("".join(real)) >= 3
 
 
+def _words_with_merged_priceless_bands(
+    words: list[dict], line_ids: set[int]
+) -> Optional[list[dict]]:
+    """Join shattered prices in bands that have no two-decimal amount.
+
+    Local import: ``blocks`` pulls ``band_words`` from this module.
+    Returns None when no band changed so the caller can skip a retry.
+    """
+    from receipt_upload.line_items.blocks import merge_price_fragments
+
+    zone = set(line_ids)
+    section = [w for w in words if w["line_id"] in zone]
+    if not section:
+        return None
+    rebuilt_zone: list[dict] = []
+    changed = False
+    for band in band_words(section):
+        if any(is_line_price_word(w) for w in band):
+            rebuilt_zone.extend(band)
+            continue
+        merged = merge_price_fragments(band)
+        if len(merged) != len(band):
+            changed = True
+        rebuilt_zone.extend(merged)
+    if not changed:
+        return None
+    outside = [w for w in words if w["line_id"] not in zone]
+    return outside + rebuilt_zone
+
+
 def extract_items(
     words: list[dict],
     line_ids: set[int],
@@ -1022,19 +1052,48 @@ def extract_items(
     non-product band filter: bands whose price merely restates a printed
     summary figure are dropped (see blocks.filter_summary_figure_items
     for the guards). Default None preserves the unfiltered decode for
-    callers that have no summary.
+    callers that have no summary (golden / Mac first pass).
+
+    When a summary is present and the constrained decode is not already
+    a match, shattered column prices (``5.``+``79``, ``5``+``.99``) are
+    trial-merged in priceless bands. The merged decode ships only if
+    reconciliation status is an exact ``match`` -- stricter than
+    ``items_boundary_extension_guard``, which would accept Costco's
+    near-0.09 from an ungated ``5,``+``90`` → 5.90.
     """
     from receipt_upload.line_items.blocks import (
         decode_band_blocks,
         load_default_priors,
     )
 
-    items = decode_band_blocks(
-        {"words": list(words), "items_line_ids": sorted(line_ids)},
-        load_default_priors(),
+    priors = load_default_priors()
+    ocr = {"words": list(words), "items_line_ids": sorted(line_ids)}
+    items = decode_band_blocks(ocr, priors, summary=summary)
+    constrained = constrain_items_to_baseline(items, summary)
+    if summary is None:
+        return constrained, False
+
+    before = reconcile_extracted_items(constrained, summary)
+    if before.status == "match":
+        return constrained, False
+
+    merged_words = _words_with_merged_priceless_bands(words, line_ids)
+    if merged_words is None:
+        return constrained, False
+
+    merged_items = decode_band_blocks(
+        {"words": merged_words, "items_line_ids": sorted(line_ids)},
+        priors,
         summary=summary,
     )
-    return constrain_items_to_baseline(items, summary), False
+    merged_constrained = constrain_items_to_baseline(merged_items, summary)
+    after = reconcile_extracted_items(merged_constrained, summary)
+    if (
+        _constraint_guard(_recon_eval(before), _recon_eval(after))
+        and after.status == "match"
+    ):
+        return merged_constrained, False
+    return constrained, False
 
 
 def _extract_items_banded(

--- a/receipt_upload/receipt_upload/line_items/labels.py
+++ b/receipt_upload/receipt_upload/line_items/labels.py
@@ -543,7 +543,9 @@ def _summary_labels(
         ]
         unique = {(int(w.line_id), int(w.word_id)): w for w in matches}
         if label == "GRAND_TOTAL":
-            word = _elect_grand_total_word(receipt_words, list(unique.values()))
+            word = _elect_grand_total_word(
+                receipt_words, list(unique.values())
+            )
             if word is None:
                 continue
             line_id, word_id = int(word.line_id), int(word.word_id)
@@ -711,7 +713,8 @@ def _phone_spans(words: Sequence[Any]) -> list[list[Any]]:
         (start, end)
         for start, end in spans
         if not any(
-            (s, e) != (start, end) and s <= start and end <= e for s, e in spans
+            (s, e) != (start, end) and s <= start and end <= e
+            for s, e in spans
         )
     ]
     return [list(words[start:end]) for start, end in maximal]

--- a/receipt_upload/tests/test_gated_price_fragments.py
+++ b/receipt_upload/tests/test_gated_price_fragments.py
@@ -1,0 +1,171 @@
+"""Gated join of OCR-shattered column prices.
+
+``merge_price_fragments`` is trialled in ``extract_items`` only when a
+printed summary is present and the merged decode then exact-matches.
+Ungated merge is forbidden: Costco ``5,``+``90`` becomes 5.90 (truth 5.99).
+"""
+
+from receipt_upload.line_items.blocks import merge_price_fragments
+from receipt_upload.line_items.geometry import (
+    evaluate_items_zone,
+    extract_items,
+)
+
+
+def W(line_id, word_id, text, x, y, h=0.04):
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "x": x,
+        "y_mid": y,
+        "h": h,
+    }
+
+
+def _decode(words, summary):
+    line_ids = {w["line_id"] for w in words}
+    items, _ = extract_items(words, line_ids, summary=summary)
+    zone = evaluate_items_zone(words, summary, line_ids)
+    return items, zone
+
+
+def test_merge_joins_trailing_separator_and_bare_dot_cents():
+    sep = [
+        W(1, 1, "EGGS", 0.05, 0.50),
+        W(2, 1, "5.", 0.81, 0.50),
+        W(2, 2, "79", 0.86, 0.50),
+    ]
+    merged = merge_price_fragments(sep)
+    assert [w["text"] for w in merged] == ["EGGS", "5.79"]
+
+    dot = [
+        W(1, 1, "TOMATOES", 0.05, 0.50),
+        W(2, 1, "5", 0.814, 0.50),
+        W(2, 2, ".99", 0.839, 0.50),
+    ]
+    merged = merge_price_fragments(dot)
+    assert [w["text"] for w in merged] == ["TOMATOES", "5.99"]
+
+
+def test_close_paren_is_not_a_decimal():
+    # 687da832: a quantity carcass, not 5.99.
+    words = [
+        W(1, 1, "FOO", 0.05, 0.50),
+        W(2, 1, "5)", 0.81, 0.50),
+        W(2, 2, "99", 0.86, 0.50),
+    ]
+    assert [w["text"] for w in merge_price_fragments(words)] == [
+        "FOO",
+        "5)",
+        "99",
+    ]
+    milk = [
+        W(3, 1, "RAW", 0.05, 0.40),
+        W(3, 2, "MILK", 0.22, 0.40),
+        W(4, 1, "10.00", 0.80, 0.40),
+    ]
+    items, zone = _decode(words + milk, {"subtotal": 15.99})
+    assert 5.99 not in [i["price"] for i in items]
+    assert zone["status"] != "match"
+
+
+def test_eggs_5_dot_plus_cents_matches_when_gated():
+    # 06e54f95: CAGE FREE BROWN EGGS shattered as 5. + 79.
+    words = [
+        W(1, 1, "CAGE", 0.05, 0.55),
+        W(1, 2, "FREE", 0.18, 0.55),
+        W(1, 3, "BROWN", 0.32, 0.55),
+        W(1, 4, "EGGS", 0.48, 0.55),
+        W(2, 1, "5.", 0.81, 0.55),
+        W(2, 2, "79", 0.86, 0.55),
+        W(3, 1, "RAW", 0.05, 0.40),
+        W(3, 2, "WHOLE", 0.18, 0.40),
+        W(3, 3, "MILK", 0.34, 0.40),
+        W(4, 1, "17.99", 0.80, 0.40),
+    ]
+    items, zone = _decode(words, {"subtotal": 23.78})
+    by_price = {i["price"]: i["name"] for i in items}
+    assert by_price[17.99] == "RAW WHOLE MILK"
+    assert by_price[5.79] == "CAGE FREE BROWN EGGS"
+    assert zone["status"] == "match"
+    assert zone["items_sum"] == 23.78
+
+
+def test_tomatoes_bare_dollars_plus_dot_cents_matches():
+    # 2f945f8d: ORG CHERRY TOMATOES shattered as 5 + .99.
+    words = [
+        W(1, 1, "ORG", 0.05, 0.62),
+        W(1, 2, "CHERRY", 0.16, 0.62),
+        W(1, 3, "TOMATOES", 0.34, 0.62),
+        W(2, 1, "5", 0.814, 0.62),
+        W(2, 2, ".99", 0.839, 0.62),
+        W(3, 1, "BABY", 0.05, 0.50),
+        W(3, 2, "SPINACH", 0.20, 0.50),
+        W(4, 1, "19.99", 0.80, 0.50),
+        W(5, 1, "CHICKEN", 0.05, 0.38),
+        W(6, 1, "17.81", 0.80, 0.38),
+    ]
+    items, zone = _decode(words, {"subtotal": 43.79})
+    by_price = {i["price"]: i["name"] for i in items}
+    assert by_price[5.99].startswith("ORG")
+    assert "TOMATOES" in by_price[5.99]
+    assert sorted(i["price"] for i in items) == [5.99, 17.81, 19.99]
+    assert zone["status"] == "match"
+    assert zone["items_sum"] == 43.79
+
+
+def test_costco_comma_fragment_near_miss_keeps_unmerged():
+    # Ungated 5,+90 → 5.90 would land near (~0.09), not match. The gate
+    # must keep the unmerged decode (mismatch by ~5.99).
+    words = [
+        W(1, 1, "KIRKLAND", 0.05, 0.55),
+        W(1, 2, "WATER", 0.28, 0.55),
+        W(2, 1, "5,", 0.81, 0.55),
+        W(2, 2, "90", 0.86, 0.55),
+        W(3, 1, "CHICKEN", 0.05, 0.40),
+        W(4, 1, "1.00", 0.80, 0.40),
+    ]
+    items, zone = _decode(words, {"subtotal": 6.99})
+    prices = [i["price"] for i in items]
+    assert 5.90 not in prices
+    assert zone["status"] == "mismatch"
+    assert zone["delta"] == -5.99
+
+
+def test_three_token_5_1_dot_99_does_not_ship_as_1_99():
+    # 57cb7f2c: do not specially join 5 + 1. + 99. If 1.+99 merges to
+    # 1.99, the receipt-level gate rejects it (not an exact match).
+    words = [
+        W(1, 1, "WIDGET", 0.05, 0.55),
+        W(2, 1, "5", 0.75, 0.55),
+        W(2, 2, "1.", 0.81, 0.55),
+        W(2, 3, "99", 0.86, 0.55),
+        W(3, 1, "MILK", 0.05, 0.40),
+        W(4, 1, "10.00", 0.80, 0.40),
+    ]
+    items, zone = _decode(words, {"subtotal": 15.99})
+    assert 1.99 not in [i["price"] for i in items]
+    assert 5.99 not in [i["price"] for i in items]
+    assert zone["status"] != "match"
+
+
+def test_summary_none_does_not_merge():
+    words = [
+        W(1, 1, "CAGE", 0.05, 0.55),
+        W(1, 2, "FREE", 0.18, 0.55),
+        W(1, 3, "BROWN", 0.32, 0.55),
+        W(1, 4, "EGGS", 0.48, 0.55),
+        W(2, 1, "5.", 0.81, 0.55),
+        W(2, 2, "79", 0.86, 0.55),
+        W(3, 1, "RAW", 0.05, 0.40),
+        W(3, 2, "WHOLE", 0.18, 0.40),
+        W(3, 3, "MILK", 0.34, 0.40),
+        W(4, 1, "17.99", 0.80, 0.40),
+    ]
+    items, _ = extract_items(
+        words, {w["line_id"] for w in words}, summary=None
+    )
+    assert 5.79 not in [i["price"] for i in items]
+    milk = [i for i in items if i["price"] == 17.99]
+    assert milk


### PR DESCRIPTION
## Summary
- OCR often splits a column price into tokens `is_line_price_word` never sees (`5.`+`79`, `5`+`.99`). This layer trial-merges those fragments **after** the normal decode + printed-total constraint, and keeps the merged decode **only** when reconciliation status is an exact `match`.
- Ungated `merge_price_fragments` in `_zone_bands` is still forbidden: Costco `5,`+`90` becomes a plausible 5.90 against truth 5.99 and would pass the looser ITEMS-boundary guard as `near` (~0.09). The exact-match gate rejects that and keeps the unmerged decode.
- Does not mint a missing price. Does not treat `)` as a decimal. Does not specially join `5`+`1.`+`99`; if `1.`+`99` merges to 1.99, the receipt-level gate rejects it unless the printed total then matches.
- `summary=None` (golden / Mac first pass) is a no-op. Cloud recompute is canonical. Swift gated trial is follow-up; `_zone_bands` still does not call `mergePriceFragments`.

Stacked on #1416 (pairing). Sibling of #1415 (TOTAL_LINE) — do not retarget.

## Test plan
- [x] `test_gated_price_fragments.py`: `06e54f95` (`5.`+`79` → 5.79, match 23.78); `2f945f8d` (`5`+`.99` → 5.99, match 43.79); Costco `5,`+`90` keeps unmerged mismatch; `5`+`1.`+`99` does not ship as 1.99; `summary=None` leaves eggs priceless; `)` is not a decimal
- [x] `test_baseline_constraint.py`
- [x] `test_two_column_pairing.py`
- [x] `test_line_item_golden_regression.py` (floors unchanged)
- [ ] CI repository-tests

```
PYTHONPATH="$WT/receipt_upload:$WT/receipt_dynamo" \
  .venv/bin/pytest \
  receipt_upload/tests/test_gated_price_fragments.py \
  receipt_upload/tests/test_baseline_constraint.py \
  receipt_upload/tests/test_two_column_pairing.py \
  receipt_upload/tests/test_line_item_golden_regression.py \
  -q
```

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that resolves an issue)

## Which Package(s) are Affected?
- [x] receipt_upload

## Related Issues
Relates to the Sprouts line-item stack after #1416.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved receipt line-item extraction when OCR splits prices across multiple text fragments.
  - Added a controlled retry process that validates reconstructed prices against receipt totals for more accurate results.

- **Bug Fixes**
  - Corrected recognition of common fragmented price formats while rejecting ambiguous patterns.
  - Preserved existing behavior when validation data is unavailable or reconstruction cannot be confirmed.

- **Documentation**
  - Added guidance for the line-item decoding workflow, validation process, and known OCR limitations.

- **Tests**
  - Added regression coverage for valid, invalid, and near-match fragmented price scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->