### PR TITLE
fix(line-items): absorb FOR-deal echoes and ITEMS-tail unit-rate META

### DIFF
--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -77,14 +77,20 @@ enum LineItemRegex {
     /// PRICE_RE (kept for stray-line detection parity; unused by decode)
     static let price = Rx("\\$?(\\d{1,4}(?:,\\d{3})?\\.\\d{2})(-?)")
     /// QTY_AT_RE: "2 @ 3.99", "1.23 lb @ 4.99/lb", "18.871 @ $5.299/Gal"
+    /// `ib` is Vision's `lb`.
     static let qtyAt = Rx(
-        "(\\d+(?:\\.\\d+)?)\\s*(?:lb|1b|kg|oz|gal)?\\s*@\\s*"
+        "(\\d+(?:\\.\\d+)?)\\s*(?:lb|1b|ib|kg|oz|gal)?\\s*@\\s*"
             + "\\$?(\\d+(?:\\.\\d{2,3}))(?:\\s*/\\s*\\w+)?",
         ci: true
     )
     /// QTY_FOR_RE: "4 FOR 1.00", "2 @ 2 FOR 3.00"
     static let qtyFor = Rx(
         "(?:(\\d{1,2})\\s*@\\s*)?(\\d{1,2})\\s+FOR\\s+\\$?(\\d+\\.\\d{2})",
+        ci: true
+    )
+    /// QTY_FOR_AMOUNT_FIRST_RE: "$2.00 FOR 3", "2.00 FOR 3 @ 3"
+    static let qtyForAmountFirst = Rx(
+        "\\$?(\\d+\\.\\d{2})\\s+FOR\\s+(\\d{1,2})(?:\\s*@\\s*\\d{1,2})?",
         ci: true
     )
     /// QTY_AT_OCR_RE: OCR reads "@" as "g" in "4 @ $1.79"
@@ -186,6 +192,45 @@ enum LineItemRegex {
     /// merge_price_fragments: left token "1." / "5," / "$12."
     static let fragmentLeft = Rx("\\$?\\d{1,4}[.,]")
     static let fragmentRight = Rx("\\d{2}")
+    /// merge_price_fragments: "5" + ".99"
+    static let fragmentBareLeft = Rx("\\$?\\d{1,4}")
+    static let fragmentDotCents = Rx("\\.\\d{2}")
+    /// PER_UNIT_RATE_RE
+    static let perUnitRate = Rx(
+        "\\bPER\\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
+        ci: true
+    )
+    /// `_SLASH_UNIT_WORD` shared by slash-rate / leftover stripping.
+    static let slashUnitWord = Rx(
+        "\\b(?:OZ|LB|LBS|1B|IB|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
+        ci: true
+    )
+    /// SLASH_UNIT_RATE_RE: "$2.99 /", "$2.99 / lb"
+    static let slashUnitRate = Rx(
+        "\\$?\\d+\\.\\d{2}\\s*/\\s*"
+            + "(?:OZ|LB|LBS|1B|IB|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)?",
+        ci: true
+    )
+    /// `_UNIT_AFTER_SLASH_RE`: `/ lb` with the amount elsewhere.
+    static let unitAfterSlash = Rx(
+        "/\\s*(?:OZ|LB|LBS|1B|IB|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
+        ci: true
+    )
+    /// `_OCR_AT_RE`
+    static let ocrAt = Rx("@|\\(\\s*a\\s*\\)", ci: true)
+    /// Weight qty plus unit, no @ (`0.32 lb`).
+    static let qtyUnitMeasure = Rx(
+        "\\d+(?:\\.\\d+)?\\s*"
+            + "(?:OZ|LB|LBS|1B|IB|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
+        ci: true
+    )
+    /// Two-decimal money token used by leftover-total detection.
+    static let twoDecimalMoney = Rx("\\$?\\d+\\.\\d{2}")
+    /// Loose number for leftover stripping.
+    static let looseNumber = Rx("\\$?\\d+(?:\\.\\d+)?")
+    static let nonWordSpace = Rx("[^\\w\\s]+")
+    /// FOR-deal leftover strip: `[@$]|\d+(?:\.\d+)?`
+    static let atDollarNumber = Rx("[@$]|\\d+(?:\\.\\d+)?")
 }
 
 /// DISCOUNT_WORDS (kept for reference; matching goes through
@@ -286,8 +331,8 @@ public func isTenderRow(_ bare: String) -> Bool {
 
 /// UNIT_WORDS: tokens that don't count as product-name content
 let unitWords: Set<String> = [
-    "EA", "LB", "KG", "OZ", "CT", "PK", "X", "C", "F", "T", "N", "O", "A",
-    "B", "TX", "FS", "QTY", "EACH",
+    "EA", "LB", "LBS", "KG", "OZ", "CT", "PK", "X", "C", "F", "T", "N", "O",
+    "A", "B", "TX", "FS", "QTY", "EACH",
 ]
 
 // MARK: - Small helpers
@@ -346,6 +391,66 @@ func nameIsReal(_ name: String) -> Bool {
     let tokens = LineItemRegex.alpha2.findAll(name)
     let real = tokens.filter { !unitWords.contains($0.uppercased()) }
     return real.reduce(0) { $0 + $1.utf16.count } >= 3
+}
+
+/// UTF-16 slice matching Python `s[:a] + " " + s[b:]`.
+private func nsSlice(_ s: String, before start: Int, after end: Int) -> String
+{
+    let ns = s as NSString
+    return pyStrip(ns.substring(to: start) + " " + ns.substring(from: end))
+}
+
+/// Port of `geometry.is_unit_rate_row`.
+func isUnitRateRow(_ text: String, nAmounts: Int) -> Bool {
+    let t = pyStrip(text)
+    if t.isEmpty { return false }
+    if LineItemRegex.perUnitRate.search(t) != nil {
+        return nAmounts <= 1
+    }
+    let qtyM = LineItemRegex.qtyAt.search(t) ?? LineItemRegex.qtyAtOcr.search(t)
+    if let qtyM {
+        let afterQty = nsSlice(t, before: qtyM.start, after: qtyM.end)
+        if LineItemRegex.twoDecimalMoney.search(afterQty) != nil {
+            return false
+        }
+    }
+    let hasRate =
+        LineItemRegex.slashUnitRate.search(t) != nil
+        || LineItemRegex.unitAfterSlash.search(t) != nil
+        || qtyM != nil
+        || LineItemRegex.ocrAt.search(t) != nil
+    if !hasRate { return false }
+    var remainder = LineItemRegex.qtyAt.sub(t, with: " ")
+    remainder = LineItemRegex.qtyAtOcr.sub(remainder, with: " ")
+    remainder = LineItemRegex.slashUnitRate.sub(remainder, with: " ")
+    remainder = LineItemRegex.unitAfterSlash.sub(remainder, with: " ")
+    remainder = LineItemRegex.ocrAt.sub(remainder, with: " ")
+    remainder = LineItemRegex.qtyUnitMeasure.sub(remainder, with: " ")
+    if LineItemRegex.twoDecimalMoney.search(remainder) != nil {
+        let nMoney = LineItemRegex.twoDecimalMoney.findAll(t).count
+        if nMoney >= 2 { return false }
+    }
+    var leftover = LineItemRegex.slashUnitWord.sub(remainder, with: " ")
+    leftover = LineItemRegex.looseNumber.sub(leftover, with: " ")
+    leftover = LineItemRegex.nonWordSpace.sub(leftover, with: " ")
+    leftover = LineItemRegex.whitespaceRun.sub(leftover, with: " ")
+    leftover = pyStrip(leftover)
+    return !nameIsReal(leftover)
+}
+
+/// Port of `geometry.is_for_deal_annotation`.
+func isForDealAnnotation(_ text: String) -> Bool {
+    let t = pyStrip(LineItemRegex.whitespaceRun.sub(text, with: " "))
+    if t.isEmpty { return false }
+    guard
+        let m = LineItemRegex.qtyFor.search(t)
+            ?? LineItemRegex.qtyForAmountFirst.search(t)
+    else { return false }
+    var leftover = nsSlice(t, before: m.start, after: m.end)
+    leftover = LineItemRegex.atDollarNumber.sub(leftover, with: " ")
+    leftover = LineItemRegex.whitespaceRun.sub(leftover, with: " ")
+    leftover = pyStrip(leftover)
+    return !nameIsReal(leftover)
 }
 
 /// Port of `blocks._sku_dominated` (decode_band_blocks variant).
@@ -416,7 +521,10 @@ let priceColumnYSep = 0.25
 
 /// Port of `geometry.is_line_price_word`.
 func isLinePriceWord(_ word: ZoneWord) -> Bool {
-    !lineAmounts([word]).isEmpty
+    if lineAmounts([word]).isEmpty { return false }
+    let text = stripTaxFlag(word.text)
+    guard let value = Amounts.parseReceiptAmount(text) else { return false }
+    return abs(value) < 100000
 }
 
 /// Port of `geometry.split_overmerged_price_bands`.
@@ -696,9 +804,21 @@ func parseBand(_ band: [ZoneWord]) -> ParsedBand? {
     var qtyWordIdxs: Set<Int> = []
     if let m = LineItemRegex.qtyFor.search(joined) {
         let dealN = Double(m.group(2)!)!
-        qty = m.group(1).flatMap(Double.init) ?? dealN
-        unitPrice = pythonRound2(Double(m.group(3)!)! / dealN)
-        qtyWordIdxs = wordsInSpan(m.start, m.end)
+        if dealN != 0 {
+            qty = m.group(1).flatMap(Double.init) ?? dealN
+            unitPrice = pythonRound2(Double(m.group(3)!)! / dealN)
+            qtyWordIdxs = wordsInSpan(m.start, m.end)
+        }
+    }
+    if qty == nil {
+        if let m = LineItemRegex.qtyForAmountFirst.search(joined) {
+            let dealN = Double(m.group(2)!)!
+            if dealN != 0 {
+                qty = dealN
+                unitPrice = pythonRound2(Double(m.group(1)!)! / dealN)
+                qtyWordIdxs = wordsInSpan(m.start, m.end)
+            }
+        }
     }
     if qty == nil {
         if let m = LineItemRegex.qtyAt.search(joined)
@@ -964,6 +1084,7 @@ func decodeBandBlocks(
             || LineItemRegex.wasPrice.hasMatch(text)
             || LineItemRegex.salePrice.hasMatch(text)
             || LineItemRegex.nonProductNote.hasMatch(text)
+            || isUnitRateRow(text, nAmounts: bands[idx].amounts.count)
         {
             bands[idx].role = "OUTSIDE"
             continue
@@ -1001,7 +1122,10 @@ func decodeBandBlocks(
     var absorbed: Set<Int> = []
     for (pos, p) in priceIdxAll.enumerated() {
         guard let mp = parsedCache[p] else { continue }
-        if nameIsReal(mp.name) { continue }
+        let forDeal = isForDealAnnotation(
+            mp.rawText.isEmpty ? bands[p].text : mp.rawText
+        )
+        if nameIsReal(mp.name) && !forDeal { continue }
         let qty = mp.quantity
         let unit = mp.unitPrice
         for npos in [pos - 1, pos + 1] {
@@ -1024,6 +1148,7 @@ func decodeBandBlocks(
             if nameIsReal(nb.name),
                 abs(mp.price) == abs(nb.price),
                 LineItemRegex.skuLike.hasMatch(mp.rawText) || qty != nil
+                    || forDeal
             {
                 if qty != nil && nb.quantity == nil {
                     nb.quantity = qty
@@ -1242,22 +1367,35 @@ public func mergePriceFragments(_ words: [ZoneWord]) -> [ZoneWord] {
         if i + 1 < ws.count {
             let nxt = ws[i + 1]
             let gap = nxt.x - w.x
-            if LineItemRegex.fragmentLeft.fullMatch(w.text) != nil,
-                LineItemRegex.fragmentRight.fullMatch(nxt.text) != nil,
-                gap >= 0, gap < 0.08
-            {
-                let merged = ZoneWord(
-                    lineId: w.lineId,
-                    wordId: w.wordId,
-                    text: w.text.replacingOccurrences(of: ",", with: ".")
-                        + nxt.text,
-                    x: w.x,
-                    yMid: w.yMid,
-                    h: w.h
-                )
-                out.append(merged)
-                i += 2
-                continue
+            if gap >= 0, gap < 0.08 {
+                let joined: String?
+                if LineItemRegex.fragmentLeft.fullMatch(w.text) != nil,
+                    LineItemRegex.fragmentRight.fullMatch(nxt.text) != nil
+                {
+                    joined =
+                        w.text.replacingOccurrences(of: ",", with: ".")
+                        + nxt.text
+                } else if LineItemRegex.fragmentBareLeft.fullMatch(w.text)
+                    != nil,
+                    LineItemRegex.fragmentDotCents.fullMatch(nxt.text) != nil
+                {
+                    joined = w.text + nxt.text
+                } else {
+                    joined = nil
+                }
+                if let joined {
+                    let merged = ZoneWord(
+                        lineId: w.lineId,
+                        wordId: w.wordId,
+                        text: joined,
+                        x: w.x,
+                        yMid: w.yMid,
+                        h: w.h
+                    )
+                    out.append(merged)
+                    i += 2
+                    continue
+                }
             }
         }
         out.append(w)

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -200,6 +200,12 @@ enum LineItemRegex {
         "\\bPER\\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
         ci: true
     )
+    /// `_PER_UNIT_AMOUNT_RE`: "$2.99 per lb" (rate amount before PER)
+    static let perUnitAmount = Rx(
+        "\\$?\\d+\\.\\d{2}\\s+"
+            + "\\bPER\\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
+        ci: true
+    )
     /// `_SLASH_UNIT_WORD` shared by slash-rate / leftover stripping.
     static let slashUnitWord = Rx(
         "\\b(?:OZ|LB|LBS|1B|IB|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\\b",
@@ -331,8 +337,8 @@ public func isTenderRow(_ bare: String) -> Bool {
 
 /// UNIT_WORDS: tokens that don't count as product-name content
 let unitWords: Set<String> = [
-    "EA", "LB", "LBS", "KG", "OZ", "CT", "PK", "X", "C", "F", "T", "N", "O",
-    "A", "B", "TX", "FS", "QTY", "EACH",
+    "EA", "LB", "LBS", "1B", "IB", "KG", "OZ", "CT", "PK", "X", "C", "F",
+    "T", "N", "O", "A", "B", "TX", "FS", "QTY", "EACH",
 ]
 
 // MARK: - Small helpers
@@ -404,8 +410,8 @@ private func nsSlice(_ s: String, before start: Int, after end: Int) -> String
 func isUnitRateRow(_ text: String, nAmounts: Int) -> Bool {
     let t = pyStrip(text)
     if t.isEmpty { return false }
-    if LineItemRegex.perUnitRate.search(t) != nil {
-        return nAmounts <= 1
+    if LineItemRegex.perUnitRate.search(t) != nil, nAmounts <= 1 {
+        return true
     }
     let qtyM = LineItemRegex.qtyAt.search(t) ?? LineItemRegex.qtyAtOcr.search(t)
     if let qtyM {
@@ -415,13 +421,16 @@ func isUnitRateRow(_ text: String, nAmounts: Int) -> Bool {
         }
     }
     let hasRate =
-        LineItemRegex.slashUnitRate.search(t) != nil
+        LineItemRegex.perUnitRate.search(t) != nil
+        || LineItemRegex.slashUnitRate.search(t) != nil
         || LineItemRegex.unitAfterSlash.search(t) != nil
         || qtyM != nil
         || LineItemRegex.ocrAt.search(t) != nil
     if !hasRate { return false }
     var remainder = LineItemRegex.qtyAt.sub(t, with: " ")
     remainder = LineItemRegex.qtyAtOcr.sub(remainder, with: " ")
+    remainder = LineItemRegex.perUnitAmount.sub(remainder, with: " ")
+    remainder = LineItemRegex.perUnitRate.sub(remainder, with: " ")
     remainder = LineItemRegex.slashUnitRate.sub(remainder, with: " ")
     remainder = LineItemRegex.unitAfterSlash.sub(remainder, with: " ")
     remainder = LineItemRegex.ocrAt.sub(remainder, with: " ")

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -1232,6 +1232,7 @@ func decodeBandBlocks(
         var donorIdxs = Set(blocks[p]!)
         donorIdxs.formUnion(unclaimed.filter { abs($0 - p) == 1 })
         donorsFor[items.count] = donorIdxs.sorted().map { bands[$0].words }
+        var qtyDonorI: Int?
         if parsed.quantity == nil {
             let donorIdxs = blocks[p]! + unclaimed.filter { abs($0 - p) == 1 }
             for i in donorIdxs {
@@ -1241,6 +1242,7 @@ func decodeBandBlocks(
                 {
                     parsed.quantity = q
                     parsed.unitPrice = u
+                    qtyDonorI = i
                     break
                 }
             }
@@ -1273,6 +1275,9 @@ func decodeBandBlocks(
         }
         var lids = Set(bands[p].lineIds)
         for i in blocks[p]! { lids.formUnion(bands[i].lineIds) }
+        if let donor = qtyDonorI {
+            lids.formUnion(bands[donor].lineIds)
+        }
         parsed.lineIds = lids.sorted()
         items.append(parsed)
     }

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -1224,7 +1224,8 @@ func decodeBandBlocks(
         donorIdxs.formUnion(unclaimed.filter { abs($0 - p) == 1 })
         donorsFor[items.count] = donorIdxs.sorted().map { bands[$0].words }
         if parsed.quantity == nil {
-            for i in blocks[p]! {
+            let donorIdxs = blocks[p]! + unclaimed.filter { abs($0 - p) == 1 }
+            for i in donorIdxs {
                 if let mp = parseBand(bands[i].words),
                     let q = mp.quantity, let u = mp.unitPrice,
                     abs(q * u - parsed.price) <= 0.02

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/LineItems/LineItemDecoder.swift
@@ -1129,6 +1129,7 @@ func decodeBandBlocks(
         if let parsed = parseBand(bands[p].words) { parsedCache[p] = parsed }
     }
     var absorbed: Set<Int> = []
+    var absorbedInto: [Int: [Int]] = [:]
     for (pos, p) in priceIdxAll.enumerated() {
         guard let mp = parsedCache[p] else { continue }
         let forDeal = isForDealAnnotation(
@@ -1151,6 +1152,7 @@ func decodeBandBlocks(
                     nb.unitPrice = uv
                 }
                 absorbed.insert(p)
+                absorbedInto[q, default: []].append(p)
                 break
             }
             // Rule 2: echo absorption ONLY into a real-named neighbor
@@ -1164,6 +1166,7 @@ func decodeBandBlocks(
                     nb.unitPrice = unit
                 }
                 absorbed.insert(p)
+                absorbedInto[q, default: []].append(p)
                 break
             }
             // Rule 3: unit-price echo with the qty prefix lost to OCR.
@@ -1187,6 +1190,7 @@ func decodeBandBlocks(
                         nb.unitPrice = mp.price
                     }
                     absorbed.insert(p)
+                    absorbedInto[q, default: []].append(p)
                     break
                 }
             }
@@ -1277,6 +1281,9 @@ func decodeBandBlocks(
         for i in blocks[p]! { lids.formUnion(bands[i].lineIds) }
         if let donor = qtyDonorI {
             lids.formUnion(bands[donor].lineIds)
+        }
+        for i in absorbedInto[p] ?? [] {
+            lids.formUnion(bands[i].lineIds)
         }
         parsed.lineIds = lids.sorted()
         items.append(parsed)

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
@@ -2603,6 +2603,7 @@
     "name_quality": null,
     "line_ids": [
      10,
+     11,
      21
     ]
    },
@@ -2718,6 +2719,7 @@
     "name_quality": null,
     "line_ids": [
      10,
+     11,
      21
     ]
    },
@@ -9599,7 +9601,8 @@
     "line_ids": [
      5,
      6,
-     7
+     7,
+     8
     ]
    }
   ],
@@ -9630,7 +9633,8 @@
     "line_ids": [
      5,
      6,
-     7
+     7,
+     8
     ]
    }
   ],
@@ -9812,6 +9816,8 @@
     "name_quality": null,
     "line_ids": [
      52,
+     53,
+     54,
      71
     ]
    },
@@ -10000,6 +10006,8 @@
     "name_quality": null,
     "line_ids": [
      52,
+     53,
+     54,
      71
     ]
    },
@@ -10895,6 +10903,7 @@
     "name_quality": null,
     "line_ids": [
      21,
+     22,
      37
     ]
    },
@@ -10907,6 +10916,7 @@
     "name_quality": null,
     "line_ids": [
      19,
+     20,
      36
     ]
    },
@@ -10919,6 +10929,7 @@
     "name_quality": null,
     "line_ids": [
      17,
+     18,
      35
     ]
    },
@@ -10943,6 +10954,7 @@
     "name_quality": null,
     "line_ids": [
      14,
+     15,
      33
     ]
    },
@@ -11023,6 +11035,7 @@
     "name_quality": null,
     "line_ids": [
      21,
+     22,
      37
     ]
    },
@@ -11035,6 +11048,7 @@
     "name_quality": null,
     "line_ids": [
      19,
+     20,
      36
     ]
    },
@@ -11047,6 +11061,7 @@
     "name_quality": null,
     "line_ids": [
      17,
+     18,
      35
     ]
    },
@@ -11071,6 +11086,7 @@
     "name_quality": null,
     "line_ids": [
      14,
+     15,
      33
     ]
    },
@@ -12214,8 +12230,11 @@
     "name_quality": null,
     "line_ids": [
      63,
+     64,
+     65,
      71,
-     72
+     72,
+     73
     ]
    },
    {
@@ -12227,7 +12246,9 @@
     "name_quality": null,
     "line_ids": [
      60,
-     69
+     61,
+     69,
+     70
     ]
    },
    {
@@ -12252,6 +12273,7 @@
     "name_quality": null,
     "line_ids": [
      54,
+     55,
      66
     ]
    },
@@ -12322,8 +12344,11 @@
     "name_quality": null,
     "line_ids": [
      63,
+     64,
+     65,
      71,
-     72
+     72,
+     73
     ]
    },
    {
@@ -12335,7 +12360,9 @@
     "name_quality": null,
     "line_ids": [
      60,
-     69
+     61,
+     69,
+     70
     ]
    },
    {
@@ -12360,6 +12387,7 @@
     "name_quality": null,
     "line_ids": [
      54,
+     55,
      66
     ]
    },

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
@@ -5601,17 +5601,6 @@
     ]
    },
    {
-    "name": "IF",
-    "price": 8.502,
-    "quantity": null,
-    "unit_price": null,
-    "is_discount": false,
-    "name_quality": "low",
-    "line_ids": [
-     121
-    ]
-   },
-   {
     "name": "OUTY 5 GALLON BUCKET GRID",
     "price": 8.76,
     "quantity": null,
@@ -6061,17 +6050,6 @@
     ]
    },
    {
-    "name": "IF",
-    "price": 8.502,
-    "quantity": null,
-    "unit_price": null,
-    "is_discount": false,
-    "name_quality": "low",
-    "line_ids": [
-     121
-    ]
-   },
-   {
     "name": "OUTY 5 GALLON BUCKET GRID",
     "price": 8.76,
     "quantity": null,
@@ -6493,7 +6471,7 @@
   ],
   "reconcile": {
    "status": "mismatch",
-   "item_sum": 1195.46,
+   "item_sum": 1186.96,
    "baseline": 1023.48,
    "baseline_source": "subtotal",
    "baseline_figures_agreeing": null
@@ -9614,8 +9592,8 @@
    {
     "name": "HOT BAR",
     "price": 10.55,
-    "quantity": 0.88,
-    "unit_price": 11.99,
+    "quantity": null,
+    "unit_price": null,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -9645,8 +9623,8 @@
    {
     "name": "HOT BAR",
     "price": 10.55,
-    "quantity": 0.88,
-    "unit_price": 11.99,
+    "quantity": null,
+    "unit_price": null,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12230,8 +12208,8 @@
    {
     "name": "SHALLOTS",
     "price": 0.84,
-    "quantity": 0.21,
-    "unit_price": 3.99,
+    "quantity": null,
+    "unit_price": null,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12268,8 +12246,8 @@
    {
     "name": "POTATO-RUSSET",
     "price": 9.74,
-    "quantity": 3.91,
-    "unit_price": 2.49,
+    "quantity": null,
+    "unit_price": null,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12338,8 +12316,8 @@
    {
     "name": "SHALLOTS",
     "price": 0.84,
-    "quantity": 0.21,
-    "unit_price": 3.99,
+    "quantity": null,
+    "unit_price": null,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12376,8 +12354,8 @@
    {
     "name": "POTATO-RUSSET",
     "price": 9.74,
-    "quantity": 3.91,
-    "unit_price": 2.49,
+    "quantity": null,
+    "unit_price": null,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
@@ -2579,6 +2579,7 @@
     "name_quality": null,
     "line_ids": [
      13,
+     14,
      23
     ]
    },
@@ -2695,6 +2696,7 @@
     "name_quality": null,
     "line_ids": [
      13,
+     14,
      23
     ]
    },
@@ -9830,6 +9832,7 @@
     "name_quality": null,
     "line_ids": [
      50,
+     51,
      70,
      95
     ]
@@ -9856,6 +9859,7 @@
     "name_quality": null,
     "line_ids": [
      44,
+     45,
      68,
      93
     ]
@@ -9882,6 +9886,7 @@
     "name_quality": null,
     "line_ids": [
      41,
+     42,
      66,
      91
     ]
@@ -9921,6 +9926,7 @@
     "name_quality": null,
     "line_ids": [
      37,
+     38,
      63,
      88
     ]
@@ -10020,6 +10026,7 @@
     "name_quality": null,
     "line_ids": [
      50,
+     51,
      70,
      95
     ]
@@ -10046,6 +10053,7 @@
     "name_quality": null,
     "line_ids": [
      44,
+     45,
      68,
      93
     ]
@@ -10072,6 +10080,7 @@
     "name_quality": null,
     "line_ids": [
      41,
+     42,
      66,
      91
     ]
@@ -10111,6 +10120,7 @@
     "name_quality": null,
     "line_ids": [
      37,
+     38,
      63,
      88
     ]
@@ -10578,6 +10588,7 @@
     "name_quality": null,
     "line_ids": [
      37,
+     38,
      53
     ]
    },
@@ -10669,6 +10680,7 @@
     "name_quality": null,
     "line_ids": [
      37,
+     38,
      53
     ]
    },
@@ -11801,6 +11813,7 @@
     "name_quality": null,
     "line_ids": [
      45,
+     46,
      55,
      73
     ]
@@ -11908,6 +11921,7 @@
     "name_quality": null,
     "line_ids": [
      45,
+     46,
      55,
      73
     ]
@@ -12260,6 +12274,7 @@
     "name_quality": null,
     "line_ids": [
      57,
+     58,
      67,
      68
     ]
@@ -12324,6 +12339,7 @@
     "name_quality": null,
     "line_ids": [
      36,
+     37,
      40,
      41
     ]
@@ -12374,6 +12390,7 @@
     "name_quality": null,
     "line_ids": [
      57,
+     58,
      67,
      68
     ]
@@ -12438,6 +12455,7 @@
     "name_quality": null,
     "line_ids": [
      36,
+     37,
      40,
      41
     ]

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/line_items_parity_expected.json
@@ -9592,8 +9592,8 @@
    {
     "name": "HOT BAR",
     "price": 10.55,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 0.88,
+    "unit_price": 11.99,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -9623,8 +9623,8 @@
    {
     "name": "HOT BAR",
     "price": 10.55,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 0.88,
+    "unit_price": 11.99,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12208,8 +12208,8 @@
    {
     "name": "SHALLOTS",
     "price": 0.84,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 0.21,
+    "unit_price": 3.99,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12221,8 +12221,8 @@
    {
     "name": "GARLIC-BULK",
     "price": 2.24,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 0.28,
+    "unit_price": 7.99,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12246,8 +12246,8 @@
    {
     "name": "POTATO-RUSSET",
     "price": 9.74,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 3.91,
+    "unit_price": 2.49,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12316,8 +12316,8 @@
    {
     "name": "SHALLOTS",
     "price": 0.84,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 0.21,
+    "unit_price": 3.99,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12329,8 +12329,8 @@
    {
     "name": "GARLIC-BULK",
     "price": 2.24,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 0.28,
+    "unit_price": 7.99,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [
@@ -12354,8 +12354,8 @@
    {
     "name": "POTATO-RUSSET",
     "price": 9.74,
-    "quantity": null,
-    "unit_price": null,
+    "quantity": 3.91,
+    "unit_price": 2.49,
     "is_discount": false,
     "name_quality": null,
     "line_ids": [

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -4723,8 +4723,8 @@
         "item_index": 0,
         "name": "SHALLOTS",
         "price": 0.84,
-        "quantity": 0.21,
-        "unit_price": 3.99,
+        "quantity": null,
+        "unit_price": null,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [
@@ -4770,8 +4770,8 @@
         "item_index": 3,
         "name": "POTATO-RUSSET",
         "price": 9.74,
-        "quantity": 3.91,
-        "unit_price": 2.49,
+        "quantity": null,
+        "unit_price": null,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -4723,8 +4723,8 @@
         "item_index": 0,
         "name": "SHALLOTS",
         "price": 0.84,
-        "quantity": null,
-        "unit_price": null,
+        "quantity": 0.21,
+        "unit_price": 3.99,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [
@@ -4739,8 +4739,8 @@
         "item_index": 1,
         "name": "GARLIC-BULK",
         "price": 2.24,
-        "quantity": null,
-        "unit_price": null,
+        "quantity": 0.28,
+        "unit_price": 7.99,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [
@@ -4770,8 +4770,8 @@
         "item_index": 3,
         "name": "POTATO-RUSSET",
         "price": 9.74,
-        "quantity": null,
-        "unit_price": null,
+        "quantity": 3.91,
+        "unit_price": 2.49,
         "is_discount": false,
         "name_quality": "ok",
         "line_ids": [

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -1119,6 +1119,7 @@
         "is_discount": false,
         "name_quality": "low",
         "line_ids": [
+          14,
           23
         ],
         "reconciliation_status": "no-baseline",
@@ -3851,6 +3852,7 @@
         "name_quality": "ok",
         "line_ids": [
           50,
+          51,
           70,
           95
         ],
@@ -3883,6 +3885,7 @@
         "name_quality": "ok",
         "line_ids": [
           44,
+          45,
           68,
           93
         ],
@@ -3963,6 +3966,7 @@
         "name_quality": "ok",
         "line_ids": [
           37,
+          38,
           63,
           88
         ],
@@ -4093,6 +4097,7 @@
         "name_quality": "ok",
         "line_ids": [
           37,
+          38,
           53
         ],
         "reconciliation_status": "match",
@@ -4771,6 +4776,7 @@
         "name_quality": "ok",
         "line_ids": [
           57,
+          58,
           67,
           68
         ],
@@ -4849,6 +4855,7 @@
         "name_quality": "ok",
         "line_ids": [
           36,
+          37,
           40,
           41
         ],

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/Fixtures/receipt_structure_parity_expected.json
@@ -1149,6 +1149,7 @@
         "name_quality": "ok",
         "line_ids": [
           10,
+          11,
           21
         ],
         "reconciliation_status": "no-baseline",
@@ -3833,6 +3834,8 @@
         "name_quality": "ok",
         "line_ids": [
           52,
+          53,
+          54,
           71
         ],
         "reconciliation_status": "no-baseline",
@@ -4210,6 +4213,7 @@
         "name_quality": "ok",
         "line_ids": [
           19,
+          20,
           36
         ],
         "reconciliation_status": "match",
@@ -4225,6 +4229,7 @@
         "name_quality": "ok",
         "line_ids": [
           17,
+          18,
           35
         ],
         "reconciliation_status": "match",
@@ -4255,6 +4260,7 @@
         "name_quality": "ok",
         "line_ids": [
           14,
+          15,
           33
         ],
         "reconciliation_status": "match",
@@ -4729,8 +4735,11 @@
         "name_quality": "ok",
         "line_ids": [
           63,
+          64,
+          65,
           71,
-          72
+          72,
+          73
         ],
         "reconciliation_status": "no-baseline",
         "raw_text": "SHALLOTS 0.84 F"
@@ -4745,7 +4754,9 @@
         "name_quality": "ok",
         "line_ids": [
           60,
-          69
+          61,
+          69,
+          70
         ],
         "reconciliation_status": "no-baseline",
         "raw_text": "GARLIC-BULK 2.24 F"
@@ -4776,6 +4787,7 @@
         "name_quality": "ok",
         "line_ids": [
           54,
+          55,
           66
         ],
         "reconciliation_status": "no-baseline",

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -904,6 +904,7 @@ def decode_band_blocks(
                 ):
                     parsed["quantity"] = mp["quantity"]
                     parsed["unit_price"] = mp["unit_price"]
+                    parsed["qty_word_ids"] = list(mp.get("qty_word_ids") or [])
                     break
         if _sku_dominated(parsed.get("name") or ""):
             # Donor criterion is _name_is_real (>=3 alpha chars), NOT the

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -891,6 +891,7 @@ def decode_band_blocks(
             donor_idxs = list(blocks[p]) + [
                 u for u in unclaimed if abs(u - p) == 1
             ]
+            qty_donor_i = None
             for i in donor_idxs:
                 mp = parse_band(list(bands[i]["words"]))
                 if (
@@ -905,7 +906,10 @@ def decode_band_blocks(
                     parsed["quantity"] = mp["quantity"]
                     parsed["unit_price"] = mp["unit_price"]
                     parsed["qty_word_ids"] = list(mp.get("qty_word_ids") or [])
+                    qty_donor_i = i
                     break
+        else:
+            qty_donor_i = None
         if _sku_dominated(parsed.get("name") or ""):
             # Donor criterion is _name_is_real (>=3 alpha chars), NOT the
             # two-token SKU test: single-word product names ("BREAD",
@@ -933,13 +937,12 @@ def decode_band_blocks(
             # No name anywhere: keep the price, flag the quality --
             # identical semantics to the banded path.
             parsed["name_quality"] = "low"
-        parsed["line_ids"] = sorted(
-            set(bands[p]["line_ids"]).union(
-                *(bands[i]["line_ids"] for i in blocks[p])
-            )
-            if blocks[p]
-            else set(bands[p]["line_ids"])
-        )
+        lids = set(bands[p]["line_ids"])
+        if blocks[p]:
+            lids.update(*(bands[i]["line_ids"] for i in blocks[p]))
+        if qty_donor_i is not None:
+            lids.update(bands[qty_donor_i]["line_ids"])
+        parsed["line_ids"] = sorted(lids)
         items.append(parsed)
     # Quantity attachment runs before the summary-figure filter purely so
     # donor indices line up with `items`; the filter reads only price,

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -738,7 +738,11 @@ def decode_band_blocks(
     # an ADJACENT price band when its qty*unit explains that neighbor's
     # price, or when it merely echoes the neighbor's price with SKU/qty
     # signature. Absorbed bands transplant quantity and stop being items.
-    from receipt_upload.line_items.geometry import SKU_LIKE_RE, _name_is_real
+    from receipt_upload.line_items.geometry import (
+        SKU_LIKE_RE,
+        _name_is_real,
+        is_for_deal_annotation,
+    )
 
     # zone price column (same convention as decode_blocks: right-most
     # amount-word x; "in column" = within 0.15)
@@ -753,7 +757,16 @@ def decode_band_blocks(
     absorbed: set[int] = set()
     for pos, p in enumerate(price_idx):
         mp = parsed_cache[p]
-        if mp is None or _name_is_real(mp.get("name") or ""):
+        if mp is None:
+            continue
+        for_deal = is_for_deal_annotation(
+            mp.get("raw_text") or bands[p]["text"]
+        )
+        # FOR-deal annotations ("2.00 FOR 3 @ 3") carry letters, so
+        # _name_is_real is true and the unnamed-echo path never runs.
+        # A named SKU that is not a FOR-deal still skips absorption
+        # (Wild Fork two items at 8.98).
+        if _name_is_real(mp.get("name") or "") and not for_deal:
             continue
         qty, unit = mp.get("quantity"), mp.get("unit_price")
         for npos in (pos - 1, pos + 1):
@@ -785,6 +798,7 @@ def decode_band_blocks(
                 and (
                     SKU_LIKE_RE.search(mp.get("raw_text") or "")
                     or qty is not None
+                    or for_deal
                 )
             ):
                 if qty is not None and nb.get("quantity") is None:

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -885,7 +885,13 @@ def decode_band_blocks(
             )
         ]
         if parsed.get("quantity") is None:
-            for i in blocks[p]:
+            # OUTSIDE unit-rate neighbours (`0.21 lb @ 3.99`) are not
+            # MEMBER bands, so they never land in `blocks[p]`. They still
+            # carry the printed qty that multiplies out to this item.
+            donor_idxs = list(blocks[p]) + [
+                u for u in unclaimed if abs(u - p) == 1
+            ]
+            for i in donor_idxs:
                 mp = parse_band(list(bands[i]["words"]))
                 if (
                     mp

--- a/receipt_upload/receipt_upload/line_items/blocks.py
+++ b/receipt_upload/receipt_upload/line_items/blocks.py
@@ -755,6 +755,7 @@ def decode_band_blocks(
         p: parse_band(list(bands[p]["words"])) for p in price_idx
     }
     absorbed: set[int] = set()
+    absorbed_into: dict[int, list[int]] = {}
     for pos, p in enumerate(price_idx):
         mp = parsed_cache[p]
         if mp is None:
@@ -785,7 +786,9 @@ def decode_band_blocks(
             ):
                 if nb.get("quantity") is None:
                     nb["quantity"], nb["unit_price"] = qty, unit
+                    nb["qty_word_ids"] = list(mp.get("qty_word_ids") or [])
                 absorbed.add(p)
+                absorbed_into.setdefault(q, []).append(p)
                 break
             # Echo absorption ONLY into a real-named neighbor -- the same
             # constraint extract_items enforces via kind==ITEM. Without it,
@@ -803,7 +806,9 @@ def decode_band_blocks(
             ):
                 if qty is not None and nb.get("quantity") is None:
                     nb["quantity"], nb["unit_price"] = qty, unit
+                    nb["qty_word_ids"] = list(mp.get("qty_word_ids") or [])
                 absorbed.add(p)
+                absorbed_into.setdefault(q, []).append(p)
                 break
             # Unit-price echo with the qty prefix lost to OCR ("2 @ 3.49"
             # reads as bare "3.49" under a 6.98 item): a bare-amount band
@@ -838,6 +843,7 @@ def decode_band_blocks(
                         nb["quantity"] = float(k)
                         nb["unit_price"] = mp["price"]
                     absorbed.add(p)
+                    absorbed_into.setdefault(q, []).append(p)
                     break
     price_idx = [p for p in price_idx if p not in absorbed]
     blocks: dict[int, list[int]] = {p: [] for p in price_idx}
@@ -942,6 +948,8 @@ def decode_band_blocks(
             lids.update(*(bands[i]["line_ids"] for i in blocks[p]))
         if qty_donor_i is not None:
             lids.update(bands[qty_donor_i]["line_ids"])
+        for i in absorbed_into.get(p, []):
+            lids.update(bands[i]["line_ids"])
         parsed["line_ids"] = sorted(lids)
         items.append(parsed)
     # Quantity attachment runs before the summary-figure filter purely so

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -1178,11 +1178,13 @@ def extract_items(
     callers that have no summary (golden / Mac first pass).
 
     When a summary is present and the constrained decode is not already
-    a match, shattered column prices (``5.``+``79``, ``5``+``.99``) are
-    trial-merged in priceless bands. The merged decode ships only if
-    reconciliation status is an exact ``match`` -- stricter than
-    ``items_boundary_extension_guard``, which would accept Costco's
-    near-0.09 from an ungated ``5,``+``90`` → 5.90.
+    cent-exact against the printed total, shattered column prices
+    (``5.``+``79``, ``5``+``.99``) are trial-merged in priceless bands.
+    A tolerant ``match`` (1% of baseline) is not enough to skip the
+    retry: a missing ``$0.99`` beside a ``$100`` item is still a
+    ``match``. The merged decode ships only on a cent-exact hit --
+    Costco's ``5,``+``90`` → 5.90 can sit inside the 1% window on a
+    ≥$9 total.
     """
     from receipt_upload.line_items.blocks import (
         decode_band_blocks,
@@ -1197,7 +1199,12 @@ def extract_items(
         return constrained, False
 
     before = reconcile_extracted_items(constrained, summary)
-    if before.status == "match":
+    before_exact = (
+        before.item_sum is not None
+        and before.baseline is not None
+        and abs(before.item_sum - before.baseline) < 0.005
+    )
+    if before_exact:
         return constrained, False
 
     merged_words = _words_with_merged_priceless_bands(words, line_ids)
@@ -1213,17 +1220,16 @@ def extract_items(
     after = reconcile_extracted_items(merged_constrained, summary)
     # ``match`` is tolerant (max $0.02 or 1% of baseline). Costco
     # ``5,``+``90`` → 5.90 can land inside that window on a ≥$9 total.
-    # Keep the merge only on a cent-exact printed-total hit.
+    # Keep the merge only on a cent-exact printed-total hit. Do not
+    # require ``_constraint_guard`` status improvement: a tolerant
+    # ``match`` that is not cent-exact (missing $0.99 on a $100 ticket)
+    # must still be replaceable by the exact merged decode.
     exact = (
         after.item_sum is not None
         and after.baseline is not None
         and abs(after.item_sum - after.baseline) < 0.005
     )
-    if (
-        _constraint_guard(_recon_eval(before), _recon_eval(after))
-        and after.status == "match"
-        and exact
-    ):
+    if exact:
         return merged_constrained, False
     return constrained, False
 

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -397,6 +397,14 @@ PER_UNIT_RATE_RE = re.compile(
     r"\bPER\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\b",
     re.IGNORECASE,
 )
+# Operand strip for leftover: the rate amount sits before PER, unlike
+# ``$2.99 / lb`` which SLASH_UNIT_RATE_RE already consumes. Do not eat a
+# trailing two-decimal — that is the extended total (``… per lb 0.96``).
+_PER_UNIT_AMOUNT_RE = re.compile(
+    r"\$?\d+\.\d{2}\s+"
+    r"\bPER\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\b",
+    re.IGNORECASE,
+)
 # Slash unit-rate annotation: "$2.99 /", "$2.99 / lb", "lb $2.99 / lb".
 # ``Ib`` / ``1b`` are Vision's ``lb``. A qty-at prefix ("0.31 Ib @") may
 # glue onto the same band; leftover after stripping qty/units/at must not
@@ -429,25 +437,32 @@ def is_unit_rate_row(text: str, n_amounts: int) -> bool:
     that annotation: after stripping qty-at, slash-rate, units, and
     ``@``/``(a)``, nothing named remains. A named qty-at line
     (``SHALLOTS 0.57 lb @ $1.69``) keeps the product letters and stays
-    an item.     ``n_amounts >= 2`` keeps a deli ``per lb`` total, but a weight
-    token (``0.32 lb $2.99 / lb``) also parses as a second amount.
-    Slash-rate / qty-at rows therefore use leftover letters, not the
-    amount count: empty leftover is still the annotation. Glued
-    ``3@15.28 45.84`` (Home Depot) has the extended total after the
+    an item. ``n_amounts >= 2`` used to keep every spelled-out ``per lb``
+    row as an item, but a weight token (``0.32 lb $2.99 per lb``) also
+    parses as a second amount. Slash-rate / qty-at / PER rows therefore
+    use leftover letters, not the amount count, once more than one amount
+    is present: empty leftover is still the annotation. A single-amount
+    PER row (Yogurtland ``Weight: … per oz``) still returns true before
+    leftover, because ``Weight`` would otherwise look like a product.
+    Glued ``3@15.28 45.84`` (Home Depot) has the extended total after the
     qty-at token and must stay an item.
     """
     t = (text or "").strip()
     if not t:
         return False
-    if PER_UNIT_RATE_RE.search(t):
-        return n_amounts <= 1
+    if PER_UNIT_RATE_RE.search(t) and n_amounts <= 1:
+        # Yogurtland "Weight: 21.5 oz … $0.67 per oz": leftover letters
+        # include "Weight", so the operand path would keep it as an item.
+        # A single amount that IS the rate is still the annotation.
+        return True
     qty_m = QTY_AT_RE.search(t) or QTY_AT_OCR_RE.search(t)
     if qty_m:
         after_qty = (t[: qty_m.start()] + " " + t[qty_m.end() :]).strip()
         if re.search(r"\$?\d+\.\d{2}", after_qty):
             return False
     has_rate = bool(
-        SLASH_UNIT_RATE_RE.search(t)
+        PER_UNIT_RATE_RE.search(t)
+        or SLASH_UNIT_RATE_RE.search(t)
         or _UNIT_AFTER_SLASH_RE.search(t)
         or qty_m
         or _OCR_AT_RE.search(t)
@@ -456,6 +471,8 @@ def is_unit_rate_row(text: str, n_amounts: int) -> bool:
         return False
     remainder = QTY_AT_RE.sub(" ", t)
     remainder = QTY_AT_OCR_RE.sub(" ", remainder)
+    remainder = _PER_UNIT_AMOUNT_RE.sub(" ", remainder)
+    remainder = PER_UNIT_RATE_RE.sub(" ", remainder)
     remainder = SLASH_UNIT_RATE_RE.sub(" ", remainder)
     remainder = _UNIT_AFTER_SLASH_RE.sub(" ", remainder)
     remainder = _OCR_AT_RE.sub(" ", remainder)
@@ -1929,7 +1946,15 @@ def _is_skippable_annotation_row(row_words: list[dict]) -> bool:
                 None,
                 0,
             )
-            if not priced:
+            leftover = re.sub(r"\bBOGO\b", " ", text or "", flags=re.I)
+            leftover = re.sub(r"\d+\s*%", " ", leftover)
+            leftover = re.sub(r"\bOFF\b", " ", leftover, flags=re.I)
+            leftover = re.sub(r"[@$]|\d+(?:\.\d+)?", " ", leftover)
+            leftover = re.sub(r"\s+", " ", leftover).strip()
+            promo = bool(re.search(r"\d+\s*%|\bOFF\b", text or "", re.I))
+            # Promo remnants ("BOGO 50% OFF GROC") skip. A real name
+            # that merely contains BOGO ("DW Backwall BOGO") does not.
+            if not priced and (promo or not _name_is_real(leftover)):
                 saw_unpriced_bogo = True
     return saw_sale_was or saw_unpriced_bogo
 

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -31,7 +31,7 @@ from receipt_dynamo.amounts import (
 PRICE_RE = re.compile(r"\$?(\d{1,4}(?:,\d{3})?\.\d{2})(-?)")
 # "2 @ 3.99", "1.23 lb @ 4.99/lb", "18.871 @ $5.299/Gal"
 QTY_AT_RE = re.compile(
-    r"(\d+(?:\.\d+)?)\s*(?:lb|1b|kg|oz|gal)?\s*@\s*\$?(\d+(?:\.\d{2,3}))"
+    r"(\d+(?:\.\d+)?)\s*(?:lb|1b|ib|kg|oz|gal)?\s*@\s*\$?(\d+(?:\.\d{2,3}))"
     r"(?:\s*/\s*\w+)?",
     re.IGNORECASE,
 )
@@ -398,15 +398,22 @@ PER_UNIT_RATE_RE = re.compile(
     re.IGNORECASE,
 )
 # Slash unit-rate annotation: "$2.99 /", "$2.99 / lb", "lb $2.99 / lb".
-# Whole-text only -- a qty line "1.23 lb @ $4.99/lb" contains the same
-# "$N.NN/" glyph but QTY_AT_RE already attaches it to the extended total.
-_SLASH_UNIT_WORD = r"(?:OZ|LB|LBS|1B|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)"
+# ``Ib`` / ``1b`` are Vision's ``lb``. A qty-at prefix ("0.31 Ib @") may
+# glue onto the same band; leftover after stripping qty/units/at must not
+# be a product name or this is a real SKU line ("SHALLOTS 0.57 lb @ …").
+_SLASH_UNIT_WORD = r"(?:OZ|LB|LBS|1B|IB|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)"
 SLASH_UNIT_RATE_RE = re.compile(
-    rf"^(?:{_SLASH_UNIT_WORD}\s+)*"
-    rf"\$?\d+\.\d{{2}}\s*/\s*"
-    rf"(?:{_SLASH_UNIT_WORD}\s*)*$",
+    rf"\$?\d+\.\d{{2}}\s*/\s*(?:{_SLASH_UNIT_WORD})?",
     re.IGNORECASE,
 )
+# ``/ lb`` with the amount elsewhere in the band. Digit-slash-digit
+# fractions (Home Depot ``1-5/8"``) do not have a unit word after the
+# slash, so they stay SKUs even when the same row also prints ``1 LB``.
+_UNIT_AFTER_SLASH_RE = re.compile(
+    rf"/\s*{_SLASH_UNIT_WORD}\b",
+    re.IGNORECASE,
+)
+_OCR_AT_RE = re.compile(r"@|\(\s*a\s*\)", re.IGNORECASE)
 
 
 def is_unit_rate_row(text: str, n_amounts: int) -> bool:
@@ -418,21 +425,45 @@ def is_unit_rate_row(text: str, n_amounts: int) -> bool:
     amount IS the rate is an annotation, which is what makes this safe
     without a merchant list.
 
-    ``$N.NN /`` (optional unit word) is the same annotation in slash
-    form. Qty-at lines that happen to contain ``$4.99/lb`` stay items:
-    QTY_AT_RE already owns that shape, and ``n_amounts >= 2`` keeps the
-    deli total.
+    ``$N.NN /`` glued to weight OCR (``0.31 Ib @ $5.49 / 1b``) is still
+    that annotation: after stripping qty-at, slash-rate, units, and
+    ``@``/``(a)``, nothing named remains. A named qty-at line
+    (``SHALLOTS 0.57 lb @ $1.69``) keeps the product letters and stays
+    an item.     ``n_amounts >= 2`` keeps a deli ``per lb`` total, but a weight
+    token (``0.32 lb $2.99 / lb``) also parses as a second amount.
+    Slash-rate / qty-at rows therefore use leftover letters, not the
+    amount count: empty leftover is still the annotation. Glued
+    ``3@15.28 45.84`` (Home Depot) has the extended total after the
+    qty-at token and must stay an item.
     """
-    if n_amounts > 1:
-        return False
     t = (text or "").strip()
     if not t:
         return False
     if PER_UNIT_RATE_RE.search(t):
-        return True
-    if QTY_AT_RE.search(t):
+        return n_amounts <= 1
+    qty_m = QTY_AT_RE.search(t) or QTY_AT_OCR_RE.search(t)
+    if qty_m:
+        after_qty = (t[: qty_m.start()] + " " + t[qty_m.end() :]).strip()
+        if re.search(r"\$?\d+\.\d{2}", after_qty):
+            return False
+    has_rate = bool(
+        SLASH_UNIT_RATE_RE.search(t)
+        or _UNIT_AFTER_SLASH_RE.search(t)
+        or qty_m
+        or _OCR_AT_RE.search(t)
+    )
+    if not has_rate:
         return False
-    return bool(SLASH_UNIT_RATE_RE.fullmatch(t))
+    leftover = QTY_AT_RE.sub(" ", t)
+    leftover = QTY_AT_OCR_RE.sub(" ", leftover)
+    leftover = SLASH_UNIT_RATE_RE.sub(" ", leftover)
+    leftover = _UNIT_AFTER_SLASH_RE.sub(" ", leftover)
+    leftover = _OCR_AT_RE.sub(" ", leftover)
+    leftover = re.sub(rf"\b{_SLASH_UNIT_WORD}\b", " ", leftover, flags=re.I)
+    leftover = re.sub(r"\$?\d+(?:\.\d+)?", " ", leftover)
+    leftover = re.sub(r"[^\w\s]+", " ", leftover)
+    leftover = re.sub(r"\s+", " ", leftover).strip()
+    return not _name_is_real(leftover)
 
 
 # Non-product annotations that carry an amount but are never items:
@@ -1018,6 +1049,9 @@ def implied_unit_price(quantity: Any, price: Any) -> Optional[float]:
 UNIT_WORDS = {
     "EA",
     "LB",
+    "LBS",
+    "1B",
+    "IB",
     "KG",
     "OZ",
     "CT",

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -454,12 +454,22 @@ def is_unit_rate_row(text: str, n_amounts: int) -> bool:
     )
     if not has_rate:
         return False
-    leftover = QTY_AT_RE.sub(" ", t)
-    leftover = QTY_AT_OCR_RE.sub(" ", leftover)
-    leftover = SLASH_UNIT_RATE_RE.sub(" ", leftover)
-    leftover = _UNIT_AFTER_SLASH_RE.sub(" ", leftover)
-    leftover = _OCR_AT_RE.sub(" ", leftover)
-    leftover = re.sub(rf"\b{_SLASH_UNIT_WORD}\b", " ", leftover, flags=re.I)
+    remainder = QTY_AT_RE.sub(" ", t)
+    remainder = QTY_AT_OCR_RE.sub(" ", remainder)
+    remainder = SLASH_UNIT_RATE_RE.sub(" ", remainder)
+    remainder = _UNIT_AFTER_SLASH_RE.sub(" ", remainder)
+    remainder = _OCR_AT_RE.sub(" ", remainder)
+    remainder = re.sub(
+        rf"\d+(?:\.\d+)?\s*(?:{_SLASH_UNIT_WORD})\b",
+        " ",
+        remainder,
+        flags=re.I,
+    )
+    if re.search(r"\$?\d+\.\d{2}", remainder):
+        n_money = len(re.findall(r"\$?\d+\.\d{2}", t))
+        if n_money >= 2:
+            return False
+    leftover = re.sub(rf"\b{_SLASH_UNIT_WORD}\b", " ", remainder, flags=re.I)
     leftover = re.sub(r"\$?\d+(?:\.\d+)?", " ", leftover)
     leftover = re.sub(r"[^\w\s]+", " ", leftover)
     leftover = re.sub(r"\s+", " ", leftover).strip()
@@ -575,7 +585,8 @@ def is_line_price_word(word: dict) -> bool:
         and re.search(r"\d[.,]\d{2}(?!\d)", text)
     ):
         return False
-    return parse_receipt_amount(text) is not None
+    value = parse_receipt_amount(text)
+    return value is not None and abs(value) < 100000
 
 
 DISCOUNT_WORDS = ("SAVED", "SAVING", "OFF", "COUPON", "DISCOUNT", "PROMO")
@@ -808,16 +819,18 @@ def parse_band(band: list[dict]) -> Optional[dict[str, Any]]:
     m = QTY_FOR_RE.search(joined)
     if m:
         deal_n = float(m.group(2))
-        qty = float(m.group(1)) if m.group(1) else deal_n
-        unit_price = round(float(m.group(3)) / deal_n, 2)
-        qty_word_idxs = words_in_span(m.start(), m.end())
+        if deal_n:
+            qty = float(m.group(1)) if m.group(1) else deal_n
+            unit_price = round(float(m.group(3)) / deal_n, 2)
+            qty_word_idxs = words_in_span(m.start(), m.end())
     if qty is None:
         m = QTY_FOR_AMOUNT_FIRST_RE.search(joined)
         if m:
             deal_n = float(m.group(2))
-            qty = deal_n
-            unit_price = round(float(m.group(1)) / deal_n, 2)
-            qty_word_idxs = words_in_span(m.start(), m.end())
+            if deal_n:
+                qty = deal_n
+                unit_price = round(float(m.group(1)) / deal_n, 2)
+                qty_word_idxs = words_in_span(m.start(), m.end())
     if qty is None:
         m = QTY_AT_RE.search(joined) or QTY_AT_OCR_RE.search(joined)
         if m:
@@ -1181,9 +1194,18 @@ def extract_items(
     )
     merged_constrained = constrain_items_to_baseline(merged_items, summary)
     after = reconcile_extracted_items(merged_constrained, summary)
+    # ``match`` is tolerant (max $0.02 or 1% of baseline). Costco
+    # ``5,``+``90`` → 5.90 can land inside that window on a ≥$9 total.
+    # Keep the merge only on a cent-exact printed-total hit.
+    exact = (
+        after.item_sum is not None
+        and after.baseline is not None
+        and abs(after.item_sum - after.baseline) < 0.005
+    )
     if (
         _constraint_guard(_recon_eval(before), _recon_eval(after))
         and after.status == "match"
+        and exact
     ):
         return merged_constrained, False
     return constrained, False

--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -41,6 +41,13 @@ QTY_FOR_RE = re.compile(
     r"(?:(\d{1,2})\s*@\s*)?(\d{1,2})\s+FOR\s+\$?(\d+\.\d{2})",
     re.IGNORECASE,
 )
+# Amount-first deal annotation: "$2.00 FOR 3", "2.00 FOR 3 @ 3". Sprouts
+# prints this under the named SKU as a restatement of the same price;
+# QTY_FOR_RE cannot see it because the integer is after FOR, not before.
+QTY_FOR_AMOUNT_FIRST_RE = re.compile(
+    r"\$?(\d+\.\d{2})\s+FOR\s+(\d{1,2})(?:\s*@\s*\d{1,2})?",
+    re.IGNORECASE,
+)
 # OCR reads "@" as "g" in "4 @ $1.79"; the explicit $ keeps this from
 # matching real gram weights
 QTY_AT_OCR_RE = re.compile(r"(\d+(?:\.\d+)?)\s*g\s*\$(\d+\.\d{2,3})")
@@ -390,6 +397,16 @@ PER_UNIT_RATE_RE = re.compile(
     r"\bPER\s+(?:OZ|LB|LBS|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)\b",
     re.IGNORECASE,
 )
+# Slash unit-rate annotation: "$2.99 /", "$2.99 / lb", "lb $2.99 / lb".
+# Whole-text only -- a qty line "1.23 lb @ $4.99/lb" contains the same
+# "$N.NN/" glyph but QTY_AT_RE already attaches it to the extended total.
+_SLASH_UNIT_WORD = r"(?:OZ|LB|LBS|1B|KG|G|GAL|EA|EACH|CT|PK|ITEM|UNIT)"
+SLASH_UNIT_RATE_RE = re.compile(
+    rf"^(?:{_SLASH_UNIT_WORD}\s+)*"
+    rf"\$?\d+\.\d{{2}}\s*/\s*"
+    rf"(?:{_SLASH_UNIT_WORD}\s*)*$",
+    re.IGNORECASE,
+)
 
 
 def is_unit_rate_row(text: str, n_amounts: int) -> bool:
@@ -400,8 +417,22 @@ def is_unit_rate_row(text: str, n_amounts: int) -> bool:
     is a genuine line total that must survive. Only a row whose single
     amount IS the rate is an annotation, which is what makes this safe
     without a merchant list.
+
+    ``$N.NN /`` (optional unit word) is the same annotation in slash
+    form. Qty-at lines that happen to contain ``$4.99/lb`` stay items:
+    QTY_AT_RE already owns that shape, and ``n_amounts >= 2`` keeps the
+    deli total.
     """
-    return n_amounts <= 1 and bool(PER_UNIT_RATE_RE.search(text or ""))
+    if n_amounts > 1:
+        return False
+    t = (text or "").strip()
+    if not t:
+        return False
+    if PER_UNIT_RATE_RE.search(t):
+        return True
+    if QTY_AT_RE.search(t):
+        return False
+    return bool(SLASH_UNIT_RATE_RE.fullmatch(t))
 
 
 # Non-product annotations that carry an amount but are never items:
@@ -750,6 +781,13 @@ def parse_band(band: list[dict]) -> Optional[dict[str, Any]]:
         unit_price = round(float(m.group(3)) / deal_n, 2)
         qty_word_idxs = words_in_span(m.start(), m.end())
     if qty is None:
+        m = QTY_FOR_AMOUNT_FIRST_RE.search(joined)
+        if m:
+            deal_n = float(m.group(2))
+            qty = deal_n
+            unit_price = round(float(m.group(1)) / deal_n, 2)
+            qty_word_idxs = words_in_span(m.start(), m.end())
+    if qty is None:
         m = QTY_AT_RE.search(joined) or QTY_AT_OCR_RE.search(joined)
         if m:
             qty = float(m.group(1))
@@ -1003,6 +1041,27 @@ def _name_is_real(name: str) -> bool:
     tokens = re.findall(r"[A-Za-z]{2,}", name or "")
     real = [t for t in tokens if t.upper() not in UNIT_WORDS]
     return len("".join(real)) >= 3
+
+
+def is_for_deal_annotation(text: str) -> bool:
+    """Whether band text is a grocery N-FOR-X / X-FOR-N deal, not a SKU.
+
+    ``2.00 FOR 3 @ 3`` has letters (``FOR``), so ``_name_is_real`` treats
+    it as a named item and META absorption would refuse it. After removing
+    the deal expression, leftover letters must not form a real product
+    name -- two named SKUs that share a price (Wild Fork 8.98) stay
+    distinct.
+    """
+    t = re.sub(r"\s+", " ", (text or "").strip())
+    if not t:
+        return False
+    m = QTY_FOR_RE.search(t) or QTY_FOR_AMOUNT_FIRST_RE.search(t)
+    if not m:
+        return False
+    leftover = (t[: m.start()] + " " + t[m.end() :]).strip()
+    leftover = re.sub(r"[@$]|\d+(?:\.\d+)?", " ", leftover)
+    leftover = re.sub(r"\s+", " ", leftover).strip()
+    return not _name_is_real(leftover)
 
 
 def _words_with_merged_priceless_bands(
@@ -1792,6 +1851,33 @@ def _is_non_product_row(row_words: list[dict]) -> bool:
     return False
 
 
+def _is_skippable_annotation_row(row_words: list[dict]) -> bool:
+    """SALE_PRICE / WAS / unpriced BOGO rows that must not end a scan.
+
+    ``adjacent_chain`` used to break on ``_is_non_product_row``, so a
+    Sale Price or BOGO annotation between garlic and You-Pay stopped the
+    ITEMS-tail walk. Skip those annotations (do not append, do not break)
+    so the next priced product can be reached. Settlement still breaks.
+    Claimed HEADER skip is a later stacked PR -- not here.
+    """
+
+    saw_sale_was = False
+    saw_unpriced_bogo = False
+    for band in band_words(row_words):
+        text = " ".join(str(word.get("text") or "") for word in band)
+        if WAS_PRICE_RE.search(text) or SALE_PRICE_RE.search(text):
+            saw_sale_was = True
+        if re.search(r"\bBOGO\b", text or "", re.IGNORECASE):
+            parsed = parse_band(band)
+            priced = parsed is not None and parsed.get("price") not in (
+                None,
+                0,
+            )
+            if not priced:
+                saw_unpriced_bogo = True
+    return saw_sale_was or saw_unpriced_bogo
+
+
 def _is_priced_product_row(row_words: list[dict]) -> bool:
     """Whether one visual row is safe to consider as a boundary item."""
 
@@ -1819,8 +1905,10 @@ def propose_items_boundary_extension(
     adjacent to either edge are candidates.  Edge candidates are contiguous
     prefixes of the unclaimed zone (neutral barcode/SKU rows may separate
     printed product rows); claimed or settlement rows terminate the scan.
-    Among verified proposals, prefer the best status, then the smallest
-    absolute delta, then the smallest boundary change.
+    Unpriced SALE_PRICE / BOGO / WAS annotation rows are skipped (not
+    appended, not a terminator) so the scan can reach the next priced
+    product.  Among verified proposals, prefer the best status, then the
+    smallest absolute delta, then the smallest boundary change.
     """
 
     current = {int(line_id) for line_id in current_line_ids}
@@ -1884,6 +1972,8 @@ def propose_items_boundary_extension(
             row = visual_rows[index]
             if row["line_ids"] & (current | other_claimed):
                 break
+            if _is_skippable_annotation_row(row["words"]):
+                continue
             if _is_non_product_row(row["words"]):
                 break
             if _is_priced_product_row(row["words"]):
@@ -2019,6 +2109,9 @@ __all__ = [
     "NOISY_MONEY_RE",
     "NON_ITEM_SECTIONS",
     "PER_UNIT_RATE_RE",
+    "QTY_FOR_AMOUNT_FIRST_RE",
+    "QTY_FOR_RE",
+    "SLASH_UNIT_RATE_RE",
     "PRICE_RE",
     "PROVEN_CENT_TOLERANCE",
     "QTY_AT_RE",
@@ -2038,6 +2131,7 @@ __all__ = [
     "extract_items",
     "implied_unit_price",
     "is_column_header_row",
+    "is_for_deal_annotation",
     "is_proven",
     "is_settlement_row",
     "is_unit_rate_row",

--- a/receipt_upload/tests/test_gated_price_fragments.py
+++ b/receipt_upload/tests/test_gated_price_fragments.py
@@ -149,6 +149,24 @@ def test_costco_comma_fragment_inside_match_tolerance_still_rejected():
     assert zone["status"] != "match"
 
 
+def test_tolerant_match_still_retries_a_small_shattered_item():
+    """$100 + missing $0.99 is a 1% ``match``; still join ``0.``+``99``."""
+    words = [
+        W(1, 1, "GARLIC", 0.05, 0.55),
+        W(1, 2, "BULK", 0.18, 0.55),
+        W(2, 1, "0.", 0.81, 0.55),
+        W(2, 2, "99", 0.86, 0.55),
+        W(3, 1, "CHICKEN", 0.05, 0.40),
+        W(4, 1, "100.00", 0.80, 0.40),
+    ]
+    items, zone = _decode(words, {"subtotal": 100.99})
+    prices = [i["price"] for i in items]
+    assert 0.99 in prices
+    assert 100.00 in prices
+    assert zone["status"] == "match"
+    assert zone["items_sum"] == 100.99
+
+
 def test_three_token_5_1_dot_99_does_not_ship_as_1_99():
     # 57cb7f2c: do not specially join 5 + 1. + 99. If 1.+99 merges to
     # 1.99, the receipt-level gate rejects it (not an exact match).

--- a/receipt_upload/tests/test_gated_price_fragments.py
+++ b/receipt_upload/tests/test_gated_price_fragments.py
@@ -133,6 +133,22 @@ def test_costco_comma_fragment_near_miss_keeps_unmerged():
     assert zone["delta"] == -5.99
 
 
+def test_costco_comma_fragment_inside_match_tolerance_still_rejected():
+    """5.90 vs 9.99 is a ``match`` under 1% tolerance; the gate must not keep it."""
+    words = [
+        W(1, 1, "KIRKLAND", 0.05, 0.55),
+        W(1, 2, "WATER", 0.28, 0.55),
+        W(2, 1, "5,", 0.81, 0.55),
+        W(2, 2, "90", 0.86, 0.55),
+        W(3, 1, "CHICKEN", 0.05, 0.40),
+        W(4, 1, "4.00", 0.80, 0.40),
+    ]
+    items, zone = _decode(words, {"subtotal": 9.99})
+    prices = [i["price"] for i in items]
+    assert 5.90 not in prices
+    assert zone["status"] != "match"
+
+
 def test_three_token_5_1_dot_99_does_not_ship_as_1_99():
     # 57cb7f2c: do not specially join 5 + 1. + 99. If 1.+99 merges to
     # 1.99, the receipt-level gate rejects it (not an exact match).

--- a/receipt_upload/tests/test_qty_for_echo_items_tail.py
+++ b/receipt_upload/tests/test_qty_for_echo_items_tail.py
@@ -370,3 +370,4 @@ def test_outside_unit_rate_donor_copies_qty_word_ids():
     ids = {(q["line_id"], q["word_id"]) for q in items[0]["qty_word_ids"]}
     assert (2, 1) in ids
     assert (2, 4) in ids
+    assert 2 in items[0]["line_ids"]

--- a/receipt_upload/tests/test_qty_for_echo_items_tail.py
+++ b/receipt_upload/tests/test_qty_for_echo_items_tail.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from receipt_dynamo.entities.receipt_section import ReceiptSection
 
 from receipt_upload.line_items.geometry import (
+    _is_skippable_annotation_row,
     evaluate_items_zone,
     extract_items,
     is_for_deal_annotation,
@@ -154,8 +155,11 @@ def test_slash_unit_rate_is_meta():
     assert is_unit_rate_row("1.94 1b $0.89 / lb", 2)
     assert is_unit_rate_row("1.19 lb a $2.49 /", 2)
     assert is_unit_rate_row("0.05 lb i $17.99/", 2)
+    # Spelled-out PER with a two-decimal weight is the same annotation.
+    assert is_unit_rate_row("0.32 lb $2.99 per lb", 2)
     # Extended total still on the band is the SKU price, not META.
     assert not is_unit_rate_row("0.32 lb $2.99 / lb 0.96", 2)
+    assert not is_unit_rate_row("0.32 lb $2.99 per lb 0.96", 2)
     # Named qty-at keeps the product; n_amounts>=2 keeps the deli total.
     # Glued ``N@unit total`` is the extended price, not a rate annotation.
     assert not is_unit_rate_row("SHALLOTS 0.57 lb @ $1.69", 1)
@@ -330,3 +334,39 @@ def test_items_tail_skips_bogo_and_sale_price_to_match():
     assert -2.00 not in prices
     assert 2.99 in prices
     assert 0.10 in prices
+
+
+def test_product_name_containing_bogo_is_not_a_skippable_annotation():
+    """Golden ``DW Backwall BOGO`` is a name-only SKU, not a promo row."""
+    product = [
+        w(1, 1, "DW", 0.05, 0.50),
+        w(1, 2, "Backwall", 0.18, 0.50),
+        w(1, 3, "BOGO", 0.40, 0.50),
+    ]
+    promo = [
+        w(1, 1, "BOGO", 0.05, 0.50),
+        w(1, 2, "50%", 0.18, 0.50),
+        w(1, 3, "OFF", 0.32, 0.50),
+        w(1, 4, "GROC", 0.46, 0.50),
+    ]
+    assert not _is_skippable_annotation_row(product)
+    assert _is_skippable_annotation_row(promo)
+
+
+def test_outside_unit_rate_donor_copies_qty_word_ids():
+    """OUTSIDE ``0.28 lb @ 7.99`` donates qty provenance, not just values."""
+    words = [
+        w(1, 1, "GARLIC", 0.05, 0.50),
+        w(1, 2, "2.24", 0.80, 0.50),
+        w(2, 1, "0.28", 0.05, 0.42),
+        w(2, 2, "lb", 0.18, 0.42),
+        w(2, 3, "@", 0.28, 0.42),
+        w(2, 4, "7.99", 0.50, 0.42),
+    ]
+    items, _ = extract_items(words, {1, 2}, summary={"subtotal": 2.24})
+    assert len(items) == 1
+    assert items[0]["quantity"] == 0.28
+    assert items[0]["unit_price"] == 7.99
+    ids = {(q["line_id"], q["word_id"]) for q in items[0]["qty_word_ids"]}
+    assert (2, 1) in ids
+    assert (2, 4) in ids

--- a/receipt_upload/tests/test_qty_for_echo_items_tail.py
+++ b/receipt_upload/tests/test_qty_for_echo_items_tail.py
@@ -23,6 +23,7 @@ from receipt_upload.line_items.geometry import (
     extract_items,
     is_for_deal_annotation,
     is_unit_rate_row,
+    parse_band,
     propose_items_boundary_extension,
 )
 
@@ -63,6 +64,31 @@ def test_amount_first_for_deal_is_an_annotation_not_a_sku():
     assert is_for_deal_annotation("4 FOR 1.00")
     assert not is_for_deal_annotation("ORGANIC LIMES 2.00 FOR 3")
     assert not is_for_deal_annotation("CHICKEN THIGH 8.98")
+
+
+def test_zero_count_for_deal_does_not_crash_parse_band():
+    parsed = parse_band(
+        [
+            w(1, 1, "2.00", 0.10, 0.50),
+            w(1, 2, "FOR", 0.22, 0.50),
+            w(1, 3, "0", 0.32, 0.50),
+        ]
+    )
+    assert parsed is None or parsed.get("quantity") != 0
+
+
+def test_slash_rate_plus_extended_total_stays_an_item():
+    words = [
+        w(1, 1, "SHALLOTS", 0.05, 0.50),
+        w(2, 1, "0.32", 0.05, 0.42),
+        w(2, 2, "lb", 0.18, 0.42),
+        w(2, 3, "$2.99", 0.40, 0.42),
+        w(2, 4, "/", 0.56, 0.42),
+        w(2, 5, "lb", 0.64, 0.42),
+        w(2, 6, "0.96", 0.80, 0.42),
+    ]
+    items, _ = extract_items(words, {1, 2}, summary={"subtotal": 0.96})
+    assert [i["price"] for i in items] == [0.96]
 
 
 def test_for_deal_echo_absorbs_into_named_limes():
@@ -128,6 +154,8 @@ def test_slash_unit_rate_is_meta():
     assert is_unit_rate_row("1.94 1b $0.89 / lb", 2)
     assert is_unit_rate_row("1.19 lb a $2.49 /", 2)
     assert is_unit_rate_row("0.05 lb i $17.99/", 2)
+    # Extended total still on the band is the SKU price, not META.
+    assert not is_unit_rate_row("0.32 lb $2.99 / lb 0.96", 2)
     # Named qty-at keeps the product; n_amounts>=2 keeps the deli total.
     # Glued ``N@unit total`` is the extended price, not a rate annotation.
     assert not is_unit_rate_row("SHALLOTS 0.57 lb @ $1.69", 1)

--- a/receipt_upload/tests/test_qty_for_echo_items_tail.py
+++ b/receipt_upload/tests/test_qty_for_echo_items_tail.py
@@ -114,6 +114,10 @@ def test_for_deal_echo_absorbs_into_named_limes():
     by_price = {i["price"]: i["name"] for i in items}
     assert "LIMES" in by_price[2.00]
     assert by_price[3.99] == "MILK"
+    limes = next(i for i in items if i["price"] == 2.00)
+    assert 3 in limes["line_ids"]
+    qty_ids = {(q["line_id"], q["word_id"]) for q in limes["qty_word_ids"]}
+    assert (3, 3) in qty_ids
     zone = evaluate_items_zone(words, {"subtotal": 5.99}, {1, 2, 3, 4, 5})
     assert zone["status"] == "match"
     assert zone["items_sum"] == 5.99

--- a/receipt_upload/tests/test_qty_for_echo_items_tail.py
+++ b/receipt_upload/tests/test_qty_for_echo_items_tail.py
@@ -1,0 +1,233 @@
+"""FOR-deal echo absorption, ``$N.NN /`` unit-rate META, ITEMS-tail skip.
+
+Closes two Sprouts nears without minting prices:
+
+* ``a0301717``: band ``2.00 FOR 3 @ 3`` restates LIMES $2.00. Constraint
+  cannot drop it (``FOR`` has letters). Absorb into the adjacent named
+  SKU at the same price. Two named SKUs at 8.98 (Wild Fork) both survive.
+* ``795bc26a``: in-zone phantom ``$2.99 /`` decoded as ``lb / lb`` cancels
+  missing garlic $2.99. Mark slash unit-rates META, then skip unpriced
+  BOGO / Sale Price annotation rows so ITEMS-boundary extension can reach
+  You-Pay 1.99 + bag 0.10.
+
+Claimed-department-header skip (DAIRY) is a later stacked PR.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from receipt_dynamo.entities.receipt_section import ReceiptSection
+
+from receipt_upload.line_items.geometry import (
+    evaluate_items_zone,
+    extract_items,
+    is_for_deal_annotation,
+    is_unit_rate_row,
+    propose_items_boundary_extension,
+)
+
+IMAGE_ID = "a0301717-d765-4f34-a15d-48c362ebf9fd"
+
+
+def w(line_id, word_id, text, x, y, h=0.02):
+    return {
+        "line_id": line_id,
+        "word_id": word_id,
+        "text": text,
+        "x": x,
+        "y_mid": y,
+        "h": h,
+    }
+
+
+def _items_section(line_ids):
+    return ReceiptSection(
+        receipt_id=1,
+        image_id=IMAGE_ID,
+        section_type="ITEMS",
+        line_ids=list(line_ids),
+        row_ids=list(line_ids),
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        model_source="section-seed-v0",
+        validation_status="VALID",
+    )
+
+
+def _row(line_id, y):
+    return SimpleNamespace(row_id=line_id, line_ids=[line_id], y_min=y)
+
+
+def test_amount_first_for_deal_is_an_annotation_not_a_sku():
+    assert is_for_deal_annotation("2.00 FOR 3 @ 3")
+    assert is_for_deal_annotation("$2.00 FOR 3")
+    assert is_for_deal_annotation("4 FOR 1.00")
+    assert not is_for_deal_annotation("ORGANIC LIMES 2.00 FOR 3")
+    assert not is_for_deal_annotation("CHICKEN THIGH 8.98")
+
+
+def test_for_deal_echo_absorbs_into_named_limes():
+    # a0301717: LIMES $2.00 plus deal annotation echoing the same price.
+    words = [
+        w(1, 1, "ORGANIC", 0.05, 0.50),
+        w(1, 2, "LIMES", 0.22, 0.50),
+        w(2, 1, "2.00", 0.80, 0.50),
+        w(3, 1, "2.00", 0.10, 0.44),
+        w(3, 2, "FOR", 0.22, 0.44),
+        w(3, 3, "3", 0.32, 0.44),
+        w(3, 4, "@", 0.40, 0.44),
+        w(3, 5, "3", 0.48, 0.44),
+        w(4, 1, "MILK", 0.05, 0.38),
+        w(5, 1, "3.99", 0.80, 0.38),
+    ]
+    items, _ = extract_items(
+        words, {1, 2, 3, 4, 5}, summary={"subtotal": 5.99}
+    )
+    prices = [i["price"] for i in items]
+    assert prices.count(2.00) == 1, [i["name"] for i in items]
+    by_price = {i["price"]: i["name"] for i in items}
+    assert "LIMES" in by_price[2.00]
+    assert by_price[3.99] == "MILK"
+    zone = evaluate_items_zone(words, {"subtotal": 5.99}, {1, 2, 3, 4, 5})
+    assert zone["status"] == "match"
+    assert zone["items_sum"] == 5.99
+
+
+def test_two_named_skus_at_same_price_are_not_absorbed():
+    # Wild Fork veto: two real items both $8.98 must both survive.
+    words = [
+        w(1, 1, "CHICKEN", 0.05, 0.50),
+        w(1, 2, "THIGH", 0.22, 0.50),
+        w(2, 1, "8.98", 0.80, 0.50),
+        w(3, 1, "PORK", 0.05, 0.38),
+        w(3, 2, "BELLY", 0.22, 0.38),
+        w(4, 1, "8.98", 0.80, 0.38),
+    ]
+    items, _ = extract_items(words, {1, 2, 3, 4}, summary={"subtotal": 17.96})
+    assert sorted(i["price"] for i in items) == [8.98, 8.98]
+    names = {i["name"] for i in items}
+    assert any("CHICKEN" in n for n in names)
+    assert any("PORK" in n for n in names)
+
+
+def test_slash_unit_rate_is_meta():
+    assert is_unit_rate_row("$2.99 /", 1)
+    assert is_unit_rate_row("$2.99 / lb", 1)
+    assert is_unit_rate_row("lb $2.99 / lb", 1)
+    assert not is_unit_rate_row("1.23 lb @ $4.99/lb", 1)
+    assert not is_unit_rate_row("GROUND BEEF $4.99 per lb 7.48", 2)
+
+
+def test_slash_unit_rate_does_not_emit_lb_slash_lb():
+    # 795bc26a: shallots 0.96 (qty attach) plus in-zone ``$2.99 /``.
+    words = [
+        w(1, 1, "SHALLOTS", 0.05, 0.50),
+        w(1, 2, "0.57", 0.28, 0.50),
+        w(1, 3, "lb", 0.38, 0.50),
+        w(1, 4, "@", 0.46, 0.50),
+        w(1, 5, "$1.69", 0.54, 0.50),
+        w(2, 1, "0.96", 0.80, 0.50),
+        w(3, 1, "lb", 0.05, 0.42),
+        w(3, 2, "$2.99", 0.20, 0.42),
+        w(3, 3, "/", 0.36, 0.42),
+        w(3, 4, "lb", 0.44, 0.42),
+    ]
+    items, _ = extract_items(words, {1, 2, 3}, summary={"subtotal": 0.96})
+    prices = [i["price"] for i in items]
+    assert 2.99 not in prices
+    assert prices == [0.96]
+    assert "SHALLOTS" in items[0]["name"]
+    names = [i["name"].lower() for i in items]
+    assert not any(
+        "lb / lb" in n or n.strip() in {"lb", "/ lb"} for n in names
+    )
+
+
+def test_deli_rate_plus_total_still_emits_the_extended_price():
+    words = [
+        w(1, 1, "GROUND", 0.05, 0.50),
+        w(1, 2, "BEEF", 0.22, 0.50),
+        w(1, 3, "$4.99", 0.40, 0.50),
+        w(1, 4, "per", 0.52, 0.50),
+        w(1, 5, "lb", 0.62, 0.50),
+        w(2, 1, "7.48", 0.80, 0.50),
+    ]
+    items, _ = extract_items(words, {1, 2}, summary={"subtotal": 7.48})
+    assert [i["price"] for i in items] == [7.48]
+    assert "BEEF" in items[0]["name"]
+
+
+def test_items_tail_skips_bogo_and_sale_price_to_match():
+    """795: after dropping ``$2.99 /``, extend over garlic + You-Pay + bag.
+
+    ITEMS: romaine 3.29, broccoli 8.49, shallots 0.96, penne 3.99, phantom
+    ``$2.99 /``. Outside: garlic 2.99, unpriced BOGO, Sale Price -2.00,
+    You-Pay 1.99 with a Price-column 3.99 echo, bag 0.10. Summary 21.81
+    = 3.29+2.99+8.49+0.96+5.98+0.10. Do not count both 3.99 and 1.99 for
+    the second penne.
+    """
+    words = [
+        w(1, 1, "ROMAINE", 0.05, 0.10),
+        w(1, 2, "3.29", 0.80, 0.10),
+        w(2, 1, "BROCCOLI", 0.05, 0.16),
+        w(2, 2, "8.49", 0.80, 0.16),
+        w(3, 1, "SHALLOTS", 0.05, 0.22),
+        w(3, 2, "0.57", 0.28, 0.22),
+        w(3, 3, "lb", 0.38, 0.22),
+        w(3, 4, "@", 0.46, 0.22),
+        w(3, 5, "$1.69", 0.54, 0.22),
+        w(3, 6, "0.96", 0.80, 0.22),
+        w(4, 1, "PENNE", 0.05, 0.28),
+        w(4, 2, "3.99", 0.80, 0.28),
+        w(5, 1, "lb", 0.05, 0.34),
+        w(5, 2, "$2.99", 0.20, 0.34),
+        w(5, 3, "/", 0.36, 0.34),
+        w(5, 4, "lb", 0.44, 0.34),
+        w(6, 1, "GARLIC", 0.05, 0.40),
+        w(6, 2, "2.99", 0.80, 0.40),
+        w(7, 1, "BOGO", 0.05, 0.46),
+        w(7, 2, "50%", 0.18, 0.46),
+        w(7, 3, "OFF", 0.32, 0.46),
+        w(7, 4, "GROC", 0.46, 0.46),
+        w(8, 1, "PENNE", 0.05, 0.52),
+        w(8, 2, "Sale", 0.22, 0.52),
+        w(8, 3, "Price", 0.36, 0.52),
+        w(8, 4, "-2.00", 0.80, 0.52),
+        w(9, 1, "3.99", 0.72, 0.58, 0.012),
+        w(9, 2, "1.99", 0.85, 0.58, 0.012),
+        w(10, 1, "PAPER", 0.05, 0.64),
+        w(10, 2, "BAG", 0.22, 0.64),
+        w(10, 3, "0.10", 0.80, 0.64),
+    ]
+    items_ids = {1, 2, 3, 4, 5}
+    summary = {"subtotal": 21.81, "tax": None, "grand_total": None}
+    before = evaluate_items_zone(words, summary, items_ids)
+    assert 2.99 not in [
+        i["price"] for i in extract_items(words, items_ids, summary=summary)[0]
+    ]
+    assert before["status"] == "mismatch"
+
+    proposal = propose_items_boundary_extension(
+        words=words,
+        summary=summary,
+        current_line_ids=items_ids,
+        sections=[_items_section(sorted(items_ids))],
+        rows=[_row(i, 0.10 + (i - 1) * 0.06) for i in range(1, 11)],
+        current_row_ids=sorted(items_ids),
+    )
+    assert proposal is not None
+    added = set(proposal["added_line_ids"])
+    assert 6 in added  # garlic
+    assert 9 in added  # You-Pay 1.99
+    assert 10 in added  # bag
+    assert 7 not in added  # BOGO annotation
+    assert 8 not in added  # Sale Price stays non-item
+    assert proposal["after"]["status"] == "match"
+    assert proposal["after"]["items_sum"] == 21.81
+    extended = set(proposal["line_ids"])
+    items, _ = extract_items(words, extended, summary=summary)
+    prices = [i["price"] for i in items]
+    assert prices.count(3.99) == 1
+    assert 1.99 in prices
+    assert -2.00 not in prices
+    assert 2.99 in prices
+    assert 0.10 in prices

--- a/receipt_upload/tests/test_qty_for_echo_items_tail.py
+++ b/receipt_upload/tests/test_qty_for_echo_items_tail.py
@@ -113,8 +113,31 @@ def test_slash_unit_rate_is_meta():
     assert is_unit_rate_row("$2.99 /", 1)
     assert is_unit_rate_row("$2.99 / lb", 1)
     assert is_unit_rate_row("lb $2.99 / lb", 1)
-    assert not is_unit_rate_row("1.23 lb @ $4.99/lb", 1)
+    # Unnamed qty-at + slash-rate is the annotation, not a SKU. Pairing
+    # dropped these; a QTY_AT_RE veto used to keep them as items.
+    assert is_unit_rate_row("1.23 lb @ $4.99/lb", 1)
+    assert is_unit_rate_row("0.31 Ib @ $5.49 / 1b", 1)
+    assert is_unit_rate_row("Ib @ / 1b $5.49", 1)
+    assert is_unit_rate_row("1.94 1b $0.89 / lb", 1)
+    assert is_unit_rate_row("lb a / 1b $2.49", 1)
+    assert is_unit_rate_row("ib @ 1b $18.99", 1)
+    assert is_unit_rate_row("2 (a) 2.49", 1)
+    assert is_unit_rate_row("i $17.99/", 1)
+    # Weight OCR parses as a second amount; leftover is still unnamed.
+    assert is_unit_rate_row("0.32 lb $2.99 / lb", 2)
+    assert is_unit_rate_row("1.94 1b $0.89 / lb", 2)
+    assert is_unit_rate_row("1.19 lb a $2.49 /", 2)
+    assert is_unit_rate_row("0.05 lb i $17.99/", 2)
+    # Named qty-at keeps the product; n_amounts>=2 keeps the deli total.
+    # Glued ``N@unit total`` is the extended price, not a rate annotation.
+    assert not is_unit_rate_row("SHALLOTS 0.57 lb @ $1.69", 1)
     assert not is_unit_rate_row("GROUND BEEF $4.99 per lb 7.48", 2)
+    assert not is_unit_rate_row("3@15.28 45.84", 1)
+    assert not is_unit_rate_row("5@0.05 0.25N", 1)
+    # Home Depot fraction sizes share `/` with a later ``LB``; that is
+    # a SKU, not a unit-rate annotation.
+    assert not is_unit_rate_row('1-5/8" FINE DRYWALL SCREW 1 LB 5.97', 1)
+    assert not is_unit_rate_row("ORG A2/A2 6% FAT MLK 7.99", 1)
 
 
 def test_slash_unit_rate_does_not_emit_lb_slash_lb():
@@ -140,6 +163,54 @@ def test_slash_unit_rate_does_not_emit_lb_slash_lb():
     assert not any(
         "lb / lb" in n or n.strip() in {"lb", "/ lb"} for n in names
     )
+
+
+def test_weight_plus_slash_rate_same_band_is_meta():
+    """795 / bananas: ``0.32 lb`` parses as a second amount on the rate band."""
+    words = [
+        w(1, 1, "SHALLOTS", 0.05, 0.50),
+        w(2, 1, "0.96", 0.80, 0.50),
+        w(3, 1, "0.32", 0.05, 0.42),
+        w(3, 2, "lb", 0.18, 0.42),
+        w(3, 3, "$2.99", 0.40, 0.42),
+        w(3, 4, "/", 0.56, 0.42),
+        w(3, 5, "lb", 0.64, 0.42),
+    ]
+    items, _ = extract_items(words, {1, 2, 3}, summary={"subtotal": 0.96})
+    prices = [i["price"] for i in items]
+    assert 2.99 not in prices
+    assert prices == [0.96]
+
+
+def test_glued_qty_at_slash_rate_does_not_reemit_the_unit_price():
+    """1b441d33 / banana $0.89 /: qty-at glued to ``$N.NN /`` is META.
+
+    Line total already sits on the named SKU. Re-emitting the rate used
+    to mismatch by exactly that rate.
+    """
+    words = [
+        w(1, 1, "SOUR", 0.05, 0.50),
+        w(1, 2, "GUMMI", 0.18, 0.50),
+        w(1, 3, "WORMS", 0.32, 0.50),
+        w(1, 4, "1.70", 0.80, 0.50),
+        w(2, 1, "0.31", 0.05, 0.42),
+        w(2, 2, "Ib", 0.18, 0.42),
+        w(2, 3, "@", 0.28, 0.42),
+        w(2, 4, "$5.49", 0.40, 0.42),
+        w(2, 5, "/", 0.58, 0.42),
+        w(2, 6, "1b", 0.66, 0.42),
+        w(3, 1, "2", 0.05, 0.34),
+        w(3, 2, "(a)", 0.14, 0.34),
+        w(3, 3, "2.49", 0.80, 0.34),
+        w(4, 1, "CREAM", 0.05, 0.26),
+        w(4, 2, "CHEESE", 0.22, 0.26),
+        w(4, 3, "4.98", 0.80, 0.26),
+    ]
+    items, _ = extract_items(words, {1, 2, 3, 4}, summary={"subtotal": 6.68})
+    prices = [i["price"] for i in items]
+    assert 5.49 not in prices
+    assert 2.49 not in prices
+    assert sorted(prices) == [1.70, 4.98]
 
 
 def test_deli_rate_plus_total_still_emits_the_extended_price():

--- a/receipt_upload/tests/test_unit_rate_rows.py
+++ b/receipt_upload/tests/test_unit_rate_rows.py
@@ -73,6 +73,13 @@ RATE_ROWS = [
 RATE_PLUS_TOTAL_ROWS = [
     ("GROUND BEEF $4.99 per lb 7.48", 2),
     ("BANANAS 0.59 per lb 1.77", 2),
+    ("0.32 lb $2.99 per lb 0.96", 2),
+]
+
+
+# Weight OCR parses as a second amount; leftover is still the rate.
+WEIGHT_PLUS_RATE_ROWS = [
+    ("0.32 lb $2.99 per lb", 2),
 ]
 
 # "PER" inside a longer word. The corpus sells "PEPPER BELL GREEN EACH",
@@ -97,6 +104,13 @@ def test_a_rate_printed_beside_a_total_stays_an_item(
     text: str, n_amounts: int
 ) -> None:
     assert not is_unit_rate_row(text, n_amounts), text
+
+
+@pytest.mark.parametrize("text,n_amounts", WEIGHT_PLUS_RATE_ROWS)
+def test_a_weight_plus_per_unit_rate_is_an_annotation(
+    text: str, n_amounts: int
+) -> None:
+    assert is_unit_rate_row(text, n_amounts), text
 
 
 @pytest.mark.parametrize("text", SUBSTRING_TRAPS)


### PR DESCRIPTION
## Summary
- **a0301717 (+$2.00):** band `2.00 FOR 3 @ 3` is a deal annotation echoing LIMES $2.00. Constraint cannot drop it (`FOR` has letters). A PRICE band whose text is an N-FOR-$X or $X-FOR-N annotation **and** whose price equals an adjacent **named** neighbor is absorbed. Two named SKUs at $8.98 (Wild Fork) both survive.
- **795bc26a (−$2.09):** in-zone phantom `$2.99 /` decoded as `lb / lb` cancels missing garlic $2.99. A band with `n_amounts <= 1` whose text is essentially `$N.NN /` plus an optional unit word is META/OUTSIDE. Deli rows that print both rate and extended total (`n_amounts >= 2`) stay items; `1.23 lb @ $4.99/lb` qty lines stay attached via `QTY_AT_RE`.
- After dropping the phantom, ITEMS-boundary extension skips unpriced SALE_PRICE / BOGO / WAS annotation rows (continue, do not append, do not break) so the scan can reach You-Pay $1.99 + bag $0.10. Settlement and claimed priced rows still terminate. Guard is unchanged: strict `|delta|` shrink **and** status improve. Adding garlic + You-Pay + bag matches 21.81. Sale Price stays non-item; do not count both 3.99 and 1.99 for the second penne.
- Does not mint missing prices. Does not add merchant `if`s. Does not feed LayoutLM product labels into sections. Does **not** skip claimed department headers (`DAIRY` / sour cream `4d0507a4`) — that is the next stacked PR (zone-gap).

Stacked on #1429 (gated fragment join). Sibling of #1415 (TOTAL_LINE) — do not retarget. Zone-gap DAIRY is follow-up.

## Test plan
- [x] `test_qty_for_echo_items_tail.py`: FOR-deal echo absorbs into LIMES; Wild Fork 8.98 pair survives; `$2.99 /` does not emit `lb / lb`; deli 7.48 still emits; ITEMS tail matches 21.81 after skip + extension
- [x] `test_gated_price_fragments.py`
- [x] `test_baseline_constraint.py`
- [x] `test_two_column_pairing.py`
- [x] `test_unit_rate_rows.py`
- [x] `test_line_item_boundary_extension.py`
- [x] `test_line_item_golden_regression.py` (floors unchanged)
- [ ] CI repository-tests

```
PYTHONPATH="$WT/receipt_upload:$WT/receipt_dynamo" \
  .venv/bin/pytest \
  receipt_upload/tests/test_qty_for_echo_items_tail.py \
  receipt_upload/tests/test_gated_price_fragments.py \
  receipt_upload/tests/test_baseline_constraint.py \
  receipt_upload/tests/test_two_column_pairing.py \
  receipt_upload/tests/test_unit_rate_rows.py \
  receipt_upload/tests/test_line_item_boundary_extension.py \
  receipt_upload/tests/test_line_item_golden_regression.py \
  -q
```

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that resolves an issue)

## Which Package(s) are Affected?
- [x] receipt_upload

## Related Issues
Relates to the Sprouts line-item stack after #1429. Zone-gap DAIRY (`4d0507a4`) is the next PR.


Made with [Cursor](https://cursor.com)