### PR TITLE
fix(line-items): skip unpriced claimed headers in ITEMS zone-gap

### DIFF
--- a/receipt_upload/receipt_upload/line_items/geometry.py
+++ b/receipt_upload/receipt_upload/line_items/geometry.py
@@ -1858,7 +1858,7 @@ def _is_skippable_annotation_row(row_words: list[dict]) -> bool:
     Sale Price or BOGO annotation between garlic and You-Pay stopped the
     ITEMS-tail walk. Skip those annotations (do not append, do not break)
     so the next priced product can be reached. Settlement still breaks.
-    Claimed HEADER skip is a later stacked PR -- not here.
+    Unpriced claimed department headers are skipped separately.
     """
 
     saw_sale_was = False
@@ -1904,11 +1904,13 @@ def propose_items_boundary_extension(
     Only whole, unclaimed, priced ReceiptRows in gaps inside the ITEMS span or
     adjacent to either edge are candidates.  Edge candidates are contiguous
     prefixes of the unclaimed zone (neutral barcode/SKU rows may separate
-    printed product rows); claimed or settlement rows terminate the scan.
-    Unpriced SALE_PRICE / BOGO / WAS annotation rows are skipped (not
-    appended, not a terminator) so the scan can reach the next priced
-    product.  Among verified proposals, prefer the best status, then the
-    smallest absolute delta, then the smallest boundary change.
+    printed product rows).  Claimed priced rows (SUMMARY / TOTAL_LINE
+    amounts) and settlement rows terminate the scan.  Unpriced claimed
+    department headers are skipped (not appended, not a terminator), as
+    are unpriced SALE_PRICE / BOGO / WAS annotation rows, so the scan can
+    reach the next priced product.  Among verified proposals, prefer the
+    best status, then the smallest absolute delta, then the smallest
+    boundary change.
     """
 
     current = {int(line_id) for line_id in current_line_ids}
@@ -1970,12 +1972,21 @@ def propose_items_boundary_extension(
         chain = []
         for index in indexes:
             row = visual_rows[index]
-            if row["line_ids"] & (current | other_claimed):
+            if row["line_ids"] & current:
                 break
             if _is_skippable_annotation_row(row["words"]):
                 continue
             if _is_non_product_row(row["words"]):
                 break
+            if row["line_ids"] & other_claimed:
+                # Priced claimed rows are other-section amounts (SUMMARY /
+                # TOTAL_LINE). Unpriced claimed rows are department
+                # headers; skip them so the scan can reach the next
+                # unclaimed product. Generic: unpriced + claimed, not a
+                # name list.
+                if _is_priced_product_row(row["words"]):
+                    break
+                continue
             if _is_priced_product_row(row["words"]):
                 chain.append(row)
         return chain

--- a/receipt_upload/tests/test_line_item_boundary_extension.py
+++ b/receipt_upload/tests/test_line_item_boundary_extension.py
@@ -8,6 +8,9 @@ from types import SimpleNamespace
 from infra.receipt_line_item_updater import line_item_processor
 from receipt_dynamo.entities.receipt_section import ReceiptSection
 from receipt_upload.line_items.geometry import (
+    evaluate_items_zone,
+    extract_items,
+    parse_band,
     propose_items_boundary_extension,
 )
 
@@ -31,20 +34,27 @@ def _row(line_id: int, y: float):
     return SimpleNamespace(row_id=line_id, line_ids=[line_id], y_min=y)
 
 
-def _items_section(
-    line_ids: list[int] | None = None, validation_status: str = "VALID"
+def _section(
+    section_type: str,
+    line_ids: list[int],
+    validation_status: str = "VALID",
 ) -> ReceiptSection:
-    ids = line_ids or [1, 2]
     return ReceiptSection(
         receipt_id=1,
         image_id=IMAGE_ID,
-        section_type="ITEMS",
-        line_ids=ids,
-        row_ids=ids,
+        section_type=section_type,
+        line_ids=list(line_ids),
+        row_ids=list(line_ids),
         created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         model_source="section-seed-v0",
         validation_status=validation_status,
     )
+
+
+def _items_section(
+    line_ids: list[int] | None = None, validation_status: str = "VALID"
+) -> ReceiptSection:
+    return _section("ITEMS", line_ids or [1, 2], validation_status)
 
 
 def _product_words(
@@ -194,3 +204,128 @@ def test_automatic_extension_preserves_valid_status_and_stamps_provenance(
     assert all(
         item.source_section_status == "VALID" for item in fake.line_items
     )
+
+
+def test_skips_claimed_unpriced_department_header_to_match():
+    """4d0507a4: claimed HEADER ``DAIRY`` must not end the ITEMS-tail scan.
+
+    In-zone: broccoli 8.49, Sale Price 6.79 echo (dropped), ``20% OFF``
+    -1.70 (discount, counted only once the zone can match), gummies 4.82.
+    Past a claimed unpriced department header: sour cream 3.49.
+    8.49+3.49+4.82-1.70 = 15.10 printed. Optional claimed ``BULK`` plus
+    ``0.69 lb @ $6.99/lb`` must not be required; prefix search prefers
+    the sour-cream-only match over emitting the weight as a new SKU.
+    """
+
+    words = [
+        _word(1, 1, "BROCCOLI", 0.05, 0.10),
+        _word(1, 2, "8.49", 0.80, 0.10),
+        _word(2, 1, "Sale", 0.22, 0.14),
+        _word(2, 2, "Price", 0.36, 0.14),
+        _word(2, 3, "6.79", 0.80, 0.14),
+        _word(3, 1, "20%", 0.05, 0.18),
+        _word(3, 2, "OFF", 0.16, 0.18),
+        _word(3, 3, "ORG", 0.28, 0.18),
+        _word(3, 4, "PRODU", 0.40, 0.18),
+        _word(3, 5, "-1.70", 0.80, 0.18),
+        _word(4, 1, "GUMMIES", 0.05, 0.22),
+        _word(4, 2, "4.82", 0.80, 0.22),
+        _word(5, 1, "DAIRY", 0.05, 0.26),
+        _word(6, 1, "SOUR", 0.05, 0.30),
+        _word(6, 2, "CREAM", 0.22, 0.30),
+        _word(6, 3, "3.49", 0.80, 0.30),
+        _word(7, 1, "BULK", 0.05, 0.34),
+        _word(8, 1, "0.69", 0.05, 0.38),
+        _word(8, 2, "lb", 0.18, 0.38),
+        _word(8, 3, "@", 0.26, 0.38),
+        _word(8, 4, "$6.99", 0.36, 0.38),
+        _word(8, 5, "/", 0.52, 0.38),
+        _word(8, 6, "lb", 0.58, 0.38),
+    ]
+    discount = parse_band([w for w in words if w["line_id"] == 3])
+    assert discount is not None
+    assert discount["is_discount"] is True
+    assert discount["price"] == -1.70
+
+    items_ids = {1, 2, 3, 4}
+    summary = {"subtotal": 15.10, "tax": None, "grand_total": None}
+    in_zone, _ = extract_items(words, items_ids, summary=summary)
+    prices = [i["price"] for i in in_zone]
+    assert 6.79 not in prices
+    assert 8.49 in prices
+    assert 4.82 in prices
+    assert -1.70 in prices
+
+    before = evaluate_items_zone(words, summary, items_ids)
+    assert before["status"] == "mismatch"
+
+    proposal = propose_items_boundary_extension(
+        words=words,
+        summary=summary,
+        current_line_ids=items_ids,
+        sections=[
+            _section("ITEMS", sorted(items_ids)),
+            _section("HEADER", [5]),
+            _section("SECTION_HEADER", [7]),
+        ],
+        rows=[_row(i, 0.10 + (i - 1) * 0.04) for i in range(1, 9)],
+        current_row_ids=sorted(items_ids),
+    )
+    assert proposal is not None
+    added = set(proposal["added_line_ids"])
+    assert 6 in added
+    assert 5 not in added
+    assert 7 not in added
+    assert 8 not in added
+    assert proposal["after"]["status"] == "match"
+    assert proposal["after"]["items_sum"] == 15.10
+    extended, _ = extract_items(
+        words, set(proposal["line_ids"]), summary=summary
+    )
+    extended_prices = [i["price"] for i in extended]
+    assert 6.79 not in extended_prices
+    assert 6.99 not in extended_prices
+    assert sorted(extended_prices) == [-1.70, 3.49, 4.82, 8.49]
+
+
+def test_claimed_priced_summary_total_still_terminates():
+    # Stealing SUMMARY TOTAL 15.10, or skipping it to reach a later 15.10
+    # product, would close 10.00 -> 25.10. Priced claimed rows remain
+    # terminators, not skippable headers.
+    words = [
+        _word(1, 1, "APPLES", 0.05, 0.10),
+        _word(1, 2, "10.00", 0.80, 0.10),
+        _word(2, 1, "TOTAL", 0.05, 0.20),
+        _word(2, 2, "15.10", 0.80, 0.20),
+        _word(3, 1, "ORANGES", 0.05, 0.30),
+        _word(3, 2, "15.10", 0.80, 0.30),
+    ]
+    proposal = propose_items_boundary_extension(
+        words=words,
+        summary={"subtotal": 25.10, "tax": None, "grand_total": None},
+        current_line_ids={1},
+        sections=[_section("ITEMS", [1]), _section("SUMMARY", [2])],
+        rows=[_row(1, 0.10), _row(2, 0.20), _row(3, 0.30)],
+        current_row_ids=[1],
+    )
+    assert proposal is None
+
+
+def test_unclaimed_unpriced_header_without_product_does_not_extend():
+    words = [
+        _word(1, 1, "APPLES", 0.05, 0.10),
+        _word(1, 2, "3.00", 0.80, 0.10),
+        _word(2, 1, "BANANAS", 0.05, 0.15),
+        _word(2, 2, "2.00", 0.80, 0.15),
+        _word(3, 1, "PRODUCE", 0.05, 0.20),
+    ]
+    proposal = propose_items_boundary_extension(
+        words=words,
+        summary={"subtotal": 9.00, "tax": None, "grand_total": None},
+        current_line_ids={1, 2},
+        sections=[_items_section()],
+        rows=[_row(1, 0.10), _row(2, 0.15), _row(3, 0.20)],
+        current_row_ids=[1, 2],
+    )
+    assert proposal is None
+


### PR DESCRIPTION
## Summary
- `4d0507a4`: ITEMS stopped before claimed department header `DAIRY`, leaving `SOUR CREAM 3.49` outside the zone. In-zone broccoli 8.49 + gummies 4.82 + `20% OFF −1.70` (not counted yet) could not match printed **15.10**. Extending to sour cream lets discount-in-recon count −1.70 and match (8.49+3.49+4.82−1.70).
- `adjacent_chain` now **breaks** on the current ITEMS set and on **claimed priced** rows (do not steal SUMMARY / TOTAL_LINE amounts). It **skips** (continue, do not append) **unpriced + claimed** rows — department headers generically, not a `DAIRY`/`PRODUCE`/`BULK` name list.
- Keeps #1431 skip of unpriced SALE_PRICE / BOGO / WAS. Settlement (`_is_non_product_row` outside that skippable set) still terminates. Guard unchanged: strict |delta| shrink AND status improve. Prefix search prefers the sour-cream-only match over emitting the following `0.69 lb @ $6.99/lb` as a new SKU.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that resolves an issue)

## Which Package(s) are Affected?
- [x] receipt_upload

## Testing
- [x] Unit tests pass locally (`pytest`)
- [x] Added or updated tests for new functionality
- [x] All existing tests still pass with these changes

Synthetic fixture (no Dynamo): ITEMS broccoli 8.49, Sale Price 6.79 echo (stays dropped), `20% OFF −1.70`, gummies 4.82; claimed HEADER `DAIRY`; unclaimed `SOUR CREAM 3.49`; optional claimed `BULK` + qty-at weight. `propose_items_boundary_extension` adds sour cream and after-status is **match**. Negatives: claimed priced SUMMARY `TOTAL 15.10` still terminates; unclaimed unpriced header with no priced product beyond it does not extend.

## Related Issues
Stacked on #1431 (`feat/qty-for-echo-items-tail`). Do not retarget #1415.

## Test plan
- [x] `test_line_item_boundary_extension.py` (including 4d0507a4 dairy fixture + SUMMARY/unclaimed-header negatives)
- [x] `test_qty_for_echo_items_tail.py`
- [x] `test_gated_price_fragments.py`
- [x] `test_baseline_constraint.py`
- [x] `test_two_column_pairing.py`
- [x] `test_line_item_golden_regression.py`


Made with [Cursor](https://cursor.com)