### PR TITLE
MCP: run fix_place locally instead of the Lambda

### DIFF
--- a/scripts/receipt_mcp_server.py
+++ b/scripts/receipt_mcp_server.py
@@ -1284,21 +1284,19 @@ WARNING: This WRITES to DynamoDB.""",
         ),
         Tool(
             name="fix_place",
-            description="""Fix an incorrect merchant/place assignment on a receipt.
+            description="""Fix an incorrect merchant/place assignment on a receipt (runs locally).
 
-Invokes the fix-place Lambda which uses an LLM agent to:
-1. Read the receipt content (lines, words, labels)
-2. Extract merchant hints (name, address, phone) from the receipt text
-3. Search Google Places for the correct match
-4. Update the ReceiptPlace record in DynamoDB
+Extracts merchant/address/phone hints from the receipt's labeled words,
+searches Google Places directly, and:
+- applies the match immediately when it is unambiguous (phone digits or
+  street number confirm exactly one candidate), returning status "fixed";
+- otherwise returns status "needs_decision" with the hints and candidates
+  so YOU decide, then call set_receipt_place with the right values.
 
-Use this when a receipt's merchant name is wrong (e.g., "Mouthful Eatery"
-when the receipt clearly says "WHOLE FOODS MARKET").
+No Lambda, no inner LLM: you are the deciding agent.
 
-Returns the old and new merchant names, the new place_id, and confidence.
-
-WARNING: This WRITES to DynamoDB. Verify the receipt is misidentified first
-using get_receipt to read its content.""",
+WARNING: This can WRITE to DynamoDB (the unambiguous case). Verify the
+receipt is misidentified first using get_receipt.""",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -2357,6 +2355,7 @@ async def call_tool(
             )
         elif name == "fix_place":
             result = await fix_place_impl(
+                dynamo_client,
                 image_id=arguments["image_id"],
                 receipt_id=arguments["receipt_id"],
                 reason=arguments["reason"],
@@ -4133,6 +4132,70 @@ def _search_place_candidates(
     return candidates
 
 
+def _collect_receipt_hints(
+    dynamo_client, image_id: str, receipt_id: int
+) -> dict:
+    """Pull merchant/address/phone hints from the receipt's labeled words."""
+    words = dynamo_client.list_receipt_words_from_receipt(image_id, receipt_id)
+    text_by_key = {(w.line_id, w.word_id): w.text for w in words}
+
+    labels = []
+    last_key = None
+    while True:
+        page, last_key = dynamo_client.list_receipt_word_labels_for_receipt(
+            image_id, receipt_id, last_evaluated_key=last_key
+        )
+        labels.extend(page)
+        if last_key is None:
+            break
+
+    hints: dict[str, list[tuple[tuple[int, int], str]]] = {
+        "MERCHANT_NAME": [],
+        "ADDRESS_LINE": [],
+        "PHONE_NUMBER": [],
+    }
+    for label in labels:
+        if label.label in hints and label.validation_status != "INVALID":
+            key = (label.line_id, label.word_id)
+            text = text_by_key.get(key)
+            if text:
+                hints[label.label].append((key, text))
+
+    def joined(name: str) -> str:
+        return " ".join(t for _, t in sorted(hints[name]))
+
+    # Phones: group per line and keep only plausible numbers (10-11 digits,
+    # not a run of a single repeated digit - LayoutLM sometimes labels EMV
+    # fields like "TVR: 0000000000" as PHONE_NUMBER).
+    phone_by_line: dict[int, list[tuple[tuple[int, int], str]]] = {}
+    for key, text in hints["PHONE_NUMBER"]:
+        phone_by_line.setdefault(key[0], []).append((key, text))
+    phones = []
+    for line_id in sorted(phone_by_line):
+        candidate = " ".join(t for _, t in sorted(phone_by_line[line_id]))
+        digits = _digits(candidate)
+        if 10 <= len(digits) <= 11 and len(set(digits)) > 2:
+            phones.append(candidate)
+
+    # Fragments for matching: labeled phone text often misses the area
+    # code ("433-6773"), which still suffix-matches a candidate's number.
+    fragments = []
+    for line_id in sorted(phone_by_line):
+        digits = _digits(
+            " ".join(t for _, t in sorted(phone_by_line[line_id]))
+        )
+        if len(digits) >= 7 and len(set(digits)) > 2:
+            fragments.append(digits[-10:])
+
+    return {
+        "merchant": joined("MERCHANT_NAME"),
+        "address": joined("ADDRESS_LINE"),
+        "phone": phones[0] if phones else "",
+        "phones": phones,
+        "phone_fragments": fragments,
+    }
+
+
 async def find_places_impl(
     query: str | None = None,
     phone: str | None = None,
@@ -4328,19 +4391,273 @@ async def set_receipt_place_impl(
 
 
 async def fix_place_impl(
+    dynamo_client,
     image_id: str,
     receipt_id: int,
     reason: str,
 ) -> dict:
-    """Invoke the fix-place Lambda to correct a receipt's merchant/place."""
+    """Fix a receipt's place locally: extract hints, search Places, and
+    either apply an unambiguous match or return candidates for the
+    calling agent to decide (then call set_receipt_place)."""
     try:
-        env = os.environ.get("PORTFOLIO_ENV", "dev")
-        return await _invoke_lambda(
-            f"fix-place-{env}-fix-place",
-            {"image_id": image_id, "receipt_id": receipt_id, "reason": reason},
+        hints = await asyncio.to_thread(
+            _collect_receipt_hints, dynamo_client, image_id, receipt_id
         )
+        current = None
+        try:
+            place = await asyncio.to_thread(
+                dynamo_client.get_receipt_place, image_id, receipt_id
+            )
+            current = {
+                "merchant_name": place.merchant_name,
+                "place_id": place.place_id,
+                "formatted_address": place.formatted_address,
+                "phone_number": place.phone_number,
+            }
+        except Exception:
+            pass
+
+        query = " ".join(v for v in (hints["merchant"], hints["address"]) if v)
+        candidates = await asyncio.to_thread(
+            _search_place_candidates,
+            query or None,
+            hints["phone"] or None,
+            hints["address"] or None,
+        )
+
+        # Text-search results omit phone numbers (field mask); enrich
+        # candidates from place details so phone matching can work.
+        def _enrich(cands):
+            places = _get_places_client()
+            for c in cands:
+                if c.get("phone_number") or not c.get("place_id"):
+                    continue
+                try:
+                    details = places.get_place_details(c["place_id"])
+                except Exception:
+                    continue
+                if details:
+                    c["phone_number"] = details.formatted_phone_number
+                    c["formatted_address"] = (
+                        c.get("formatted_address") or details.formatted_address
+                    )
+            return cands
+
+        candidates = await asyncio.to_thread(_enrich, candidates)
+
+        # An unambiguous match: the receipt's phone digits equal the
+        # candidate's, or the receipt's street number appears in the
+        # candidate address. Apply it directly.
+        def _usable(c):
+            # Mirrors receipt_agent place_finder tiered._place_is_usable:
+            # reject "places" that are really just addresses - the class
+            # of Places result that caused address-as-merchant records.
+            if not c.get("place_id") or not c.get("name"):
+                return False
+            types = {str(t).lower() for t in (c.get("types") or [])}
+            address_types = {"premise", "street_address", "subpremise"}
+            business_types = {"establishment", "point_of_interest"}
+            return not (types & address_types and not types & business_types)
+
+        def _tokens(value):
+            return {
+                t
+                for t in re.sub(
+                    r"[^a-z0-9 ]", " ", (value or "").lower()
+                ).split()
+                if len(t) >= 3
+            }
+
+        merchant_tokens = _tokens(hints["merchant"])
+
+        def _names_agree(candidate_name):
+            # Meaningful agreement, not a single shared token: the overlap
+            # must cover most of the shorter name ("Trader Joe's" vs
+            # "Joe's Seafood" shares only "joe" and must NOT pass).
+            cand_tokens = _tokens(candidate_name)
+            if not merchant_tokens or not cand_tokens:
+                return False
+            overlap = len(merchant_tokens & cand_tokens)
+            shorter = min(len(merchant_tokens), len(cand_tokens))
+            if overlap / shorter < 0.6:
+                return False
+            # A single generic token ("Market") is not agreement: with a
+            # one-token hint, require the candidate name to be that
+            # token exactly.
+            if len(merchant_tokens) == 1:
+                return cand_tokens == merchant_tokens
+            return True
+
+        def _street_number(address):
+            # First plausible house number anywhere in the hint: stray
+            # city/header words can precede the street line in
+            # ADDRESS_LINE labels.
+            for token in (address or "").split():
+                t = token.strip(".,#")
+                if t.isdigit() and 1 <= len(t) <= 6:
+                    return t
+            return ""
+
+        _US_STATES = {
+            "AL",
+            "AK",
+            "AZ",
+            "AR",
+            "CA",
+            "CO",
+            "CT",
+            "DE",
+            "FL",
+            "GA",
+            "HI",
+            "ID",
+            "IL",
+            "IN",
+            "IA",
+            "KS",
+            "KY",
+            "LA",
+            "ME",
+            "MD",
+            "MA",
+            "MI",
+            "MN",
+            "MS",
+            "MO",
+            "MT",
+            "NE",
+            "NV",
+            "NH",
+            "NJ",
+            "NM",
+            "NY",
+            "NC",
+            "ND",
+            "OH",
+            "OK",
+            "OR",
+            "PA",
+            "RI",
+            "SC",
+            "SD",
+            "TN",
+            "TX",
+            "UT",
+            "VT",
+            "VA",
+            "WA",
+            "WV",
+            "WI",
+            "WY",
+            "DC",
+        }
+
+        def _state(address):
+            tokens = re.sub(
+                r"[^A-Za-z ]", " ", (address or "").upper()
+            ).split()
+            for t in reversed(tokens):
+                if t in _US_STATES:
+                    return t
+            return ""
+
+        fragments = hints.get("phone_fragments", [])
+        receipt_street = _street_number(hints["address"])
+        receipt_state = _state(hints["address"])
+        strong = []
+        for c in candidates:
+            # Auto-apply is deliberately strict (mirrors the tiered
+            # resolver's invariants): usable business listing, meaningful
+            # merchant-name agreement, at least one exact corroboration
+            # (phone or street number), and NO active clue conflict -
+            # a chain's corporate phone can match while the address
+            # identifies a different location.
+            if not _usable(c):
+                continue
+            if not _names_agree(c.get("name")):
+                continue
+            cand_phone = _digits(c.get("phone_number"))[-10:]
+            phone_match = bool(cand_phone) and any(
+                cand_phone.endswith(f) or f.endswith(cand_phone)
+                for f in fragments
+            )
+            phone_conflict = (
+                bool(cand_phone) and bool(fragments) and not phone_match
+            )
+            cand_street = _street_number(c.get("formatted_address"))
+            addr_match = (
+                bool(receipt_street)
+                and bool(cand_street)
+                and receipt_street == cand_street
+            )
+            addr_conflict = (
+                bool(receipt_street)
+                and bool(cand_street)
+                and receipt_street != cand_street
+            )
+            cand_state = _state(c.get("formatted_address"))
+            state_conflict = (
+                bool(receipt_state)
+                and bool(cand_state)
+                and receipt_state != cand_state
+            )
+            if phone_conflict or addr_conflict or state_conflict:
+                continue
+            if phone_match or addr_match:
+                strong.append((c, phone_match, addr_match))
+
+        if len(strong) == 1:
+            c, phone_match, addr_match = strong[0]
+            result = await set_receipt_place_impl(
+                dynamo_client,
+                image_id,
+                receipt_id,
+                merchant_name=c["name"],
+                place_id=c["place_id"],
+                formatted_address=c["formatted_address"],
+                phone_number=c["phone_number"],
+                reasoning=(
+                    f"{reason} | matched via "
+                    f"{'phone' if phone_match else 'street number'}"
+                ),
+                validated_by=(
+                    "PHONE_LOOKUP" if phone_match else "ADDRESS_LOOKUP"
+                ),
+                confidence=0.9 if phone_match else 0.85,
+                validation_status="MATCHED",
+                matched_fields=(["phone"] if phone_match else ["address"])
+                + ["merchant_name"],
+            )
+            if result.get("success"):
+                result["status"] = "fixed"
+                result["candidate"] = c
+                result["hints"] = hints
+                return result
+            return {
+                "status": "needs_decision",
+                "hints": hints,
+                "current": current,
+                "candidates": candidates,
+                "write_error": result.get("error"),
+                "next_step": (
+                    "Automatic apply failed; review candidates and call "
+                    "set_receipt_place directly."
+                ),
+            }
+
+        return {
+            "status": "needs_decision",
+            "hints": hints,
+            "current": current,
+            "candidates": candidates,
+            "next_step": (
+                "Review the candidates against the receipt content and call "
+                "set_receipt_place with the correct merchant_name/place_id "
+                "(or with receipt-derived values if none match)."
+            ),
+        }
     except Exception as e:
-        logger.exception("Error invoking fix-place Lambda")
+        logger.exception("Error fixing place locally")
         return {"error": str(e)}
 
 


### PR DESCRIPTION
**Stack 2/3** (base: #1/3 primitives)

Replaces the fix-place Lambda invocation with a local implementation: hint extraction from labeled words (per-line phones, plausibility-filtered against EMV junk), direct Places search with detail enrichment, and a deliberately conservative auto-apply gate mirroring `place_finder/tiered.py`: usable business types only (rejects the street_address/subpremise class that caused address-as-merchant records), receipt merchant text must corroborate the candidate, plus phone-suffix or street-number confirmation. Everything else returns `needs_decision` with hints + candidates — the calling agent decides and uses `set_receipt_place`.

Rationale: the Lambda wrapped its own LLM agent, which is redundant when the caller is an LLM with the receipt in context — and it was the slow path (container cold starts) and the failure source (null-phone validation crash, prior-driven mis-rejection of the correct CareNow match) in the 2026-08-13 session.

Live regression: Henderson TJ auto-fixes with metadata (PHONE_LOOKUP, 0.9, MATCHED); CareNow (HCA corporate phone → junk Places result) correctly hands the decision back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)