### PR TITLE
Add a deterministic browser rotoscope reference engine

### DIFF
--- a/portfolio/components/home/Rotoscope/README.md
+++ b/portfolio/components/home/Rotoscope/README.md
@@ -1,0 +1,26 @@
+# Browser rotoscope
+
+The browser implementation follows Tyler Norlund, Iain Murphy, and Vivek K.
+Pallipuram's 2017 best-features rotoscope pipeline. The paper/MATLAB behavior is
+canonical; the later MPI/OpenCV port is useful performance history but is not a
+golden implementation.
+
+The production demo uses **single-image mode** because the homepage portrait has
+no matching clean-background frame. A low-frequency blurred copy replaces that
+one input, after which the original stages remain recognizable:
+
+1. source-vs-blurred-copy difference map;
+2. analytical Shi-Tomasi minimum-eigenvalue scores;
+3. spatially suppressed markers with explicit face/body/background quotas;
+4. deterministic eight-neighbor marker-controlled watershed flooding;
+5. one mean source RGB color per watershed region.
+
+`algorithm.ts` is the readable scalar reference and correctness oracle for the
+optimized WebAssembly kernel. The authored normalized focus geometry belongs to
+the image configuration rather than the numerical stages, keeping the engine
+reusable for future portraits.
+
+The paper's stage structure remains canonical. Two numerical kernels are
+intentional display-resolution optimizations and are covered by exact fixtures:
+the browser uses an integer 3x3 Sobel instead of the MATLAB Gaussian derivative
+at sigma 0.6, and a 3x3 structure-tensor window instead of its 7x7 window.

--- a/portfolio/components/home/Rotoscope/algorithm.test.ts
+++ b/portfolio/components/home/Rotoscope/algorithm.test.ts
@@ -1,0 +1,253 @@
+import {
+  classifyFocusTier,
+  colorizeRegions,
+  DEFAULT_ROTOSCOPE_OPTIONS,
+  grayscaleAndDifference,
+  minimumEigenvalue,
+  runRotoscope,
+  selectMarkers,
+  shiTomasiScores,
+  sobelGradient,
+  validateRgba,
+  watershed,
+} from "./algorithm";
+
+const rgba = (
+  width: number,
+  height: number,
+  pixel: (x: number, y: number) => readonly [number, number, number, number],
+): Uint8ClampedArray => {
+  const output = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      output.set(pixel(x, y), (y * width + x) * 4);
+    }
+  }
+  return output;
+};
+
+test("validates dimensions and the exact RGBA byte length", () => {
+  expect(validateRgba(new Uint8ClampedArray(16), 2, 2)).toBe(4);
+  expect(() => validateRgba(new Uint8ClampedArray(15), 2, 2)).toThrow(
+    "RGBA byte length",
+  );
+  expect(() => validateRgba(new Uint8ClampedArray(0), 0, 1)).toThrow(
+    "dimensions",
+  );
+});
+
+test("single-image difference is zero for a flat image and preserves grayscale", () => {
+  const source = rgba(5, 3, () => [20, 40, 60, 77]);
+  const stage = grayscaleAndDifference(source, 5, 3, 2);
+
+  expect(new Set(stage.gray)).toEqual(new Set([36]));
+  expect(Array.from(stage.difference)).toEqual(new Array(15).fill(0));
+});
+
+test("single-image blur and difference match the exact edge fixture", () => {
+  const source = rgba(3, 1, (x) => {
+    const value = x * 100;
+    return [value, value, value, 255];
+  });
+  const stage = grayscaleAndDifference(source, 3, 1, 1);
+
+  expect(Array.from(stage.gray)).toEqual([0, 100, 200]);
+  expect(Array.from(stage.difference)).toEqual([50, 0, 50]);
+});
+
+test("non-finite public blur input uses the documented default", () => {
+  const source = rgba(5, 3, (x, y) => [x * 20, y * 30, 40, 255]);
+  const invalid = grayscaleAndDifference(source, 5, 3, Number.NaN);
+  const expected = grayscaleAndDifference(
+    source,
+    5,
+    3,
+    DEFAULT_ROTOSCOPE_OPTIONS.blurRadius,
+  );
+  expect(Array.from(invalid.difference)).toEqual(Array.from(expected.difference));
+});
+
+test("analytical minimum eigenvalue matches the closed-form diagonal cases", () => {
+  expect(minimumEigenvalue(9, 0, 4)).toBeCloseTo(4);
+  expect(minimumEigenvalue(9, 3, 9)).toBeCloseTo(6);
+  expect(minimumEigenvalue(0, 0, 0)).toBe(0);
+});
+
+test("Sobel and Shi-Tomasi stages produce bounded borders and corner response", () => {
+  const width = 9;
+  const height = 9;
+  const source = new Uint8Array(width * height);
+  for (let y = 4; y < height; y += 1) {
+    for (let x = 4; x < width; x += 1) source[y * width + x] = 255;
+  }
+  const gradient = sobelGradient(source, width, height);
+  const scores = shiTomasiScores(source, width, height);
+
+  expect(gradient.magnitude[0]).toBe(0);
+  expect([
+    gradient.x[30],
+    gradient.y[30],
+    gradient.magnitude[30],
+    gradient.x[40],
+    gradient.y[40],
+    gradient.magnitude[40],
+  ]).toEqual([255, 255, 128, 765, 765, 255]);
+  expect([scores[30], scores[31], scores[40], scores[49]]).toEqual([
+    260100,
+    869552.1875,
+    2340900,
+    1530487.375,
+  ]);
+  expect(scores[0]).toBe(0);
+});
+
+test("focus geometry classifies face before body and leaves a background tier", () => {
+  const focus = DEFAULT_ROTOSCOPE_OPTIONS.focus;
+  expect(classifyFocusTier(39, 55, 100, 100, focus)).toBe("face");
+  expect(classifyFocusTier(35, 85, 100, 100, focus)).toBe("body");
+  expect(classifyFocusTier(95, 10, 100, 100, focus)).toBe("background");
+});
+
+test("marker selection honors explicit tier budgets when geometry has capacity", () => {
+  const width = 80;
+  const height = 60;
+  const scores = new Float32Array(width * height);
+  for (let index = 0; index < scores.length; index += 1) {
+    scores[index] = ((index * 7919) % 997) + 1;
+  }
+  const selected = selectMarkers(scores, width, height, {
+    markerBudget: 20,
+    quotas: { face: 0.5, body: 0.3, background: 0.2 },
+    spacing: { face: 1, body: 1, background: 1 },
+  });
+
+  expect(selected.tierCounts).toEqual({ face: 10, body: 6, background: 4 });
+  expect(new Set(selected.indices).size).toBe(selected.indices.length);
+});
+
+test("marker allocation never exceeds tiny or adversarial budgets", () => {
+  const scores = new Float32Array(100).map((_, index) => index + 1);
+  const options = {
+    markerBudget: 1,
+    quotas: { face: 0.5, body: 0.5, background: 0 },
+    spacing: { face: 1, body: 1, background: 1 },
+  };
+  const selected = selectMarkers(scores, 10, 10, options);
+  expect(selected.indices.length).toBeLessThanOrEqual(1);
+
+  const negative = selectMarkers(scores, 10, 10, {
+    ...options,
+    markerBudget: 4,
+    quotas: { face: 1, body: -10, background: 1 },
+  });
+  expect(negative.indices.length).toBeLessThanOrEqual(4);
+  expect(negative.tierCounts.body).toBe(0);
+});
+
+test("marker ranking and tie order match the exact golden fixture", () => {
+  const scores = new Float32Array(25);
+  scores[6] = 10;
+  scores[18] = 9;
+  const selected = selectMarkers(scores, 5, 5, {
+    markerBudget: 2,
+    quotas: { face: 1, body: 0, background: 0 },
+    spacing: { face: 1, body: 1, background: 1 },
+    focus: {
+      face: { centerX: 0.5, centerY: 0.5, radiusX: 2, radiusY: 2 },
+      body: [],
+    },
+  });
+  expect(Array.from(selected.indices)).toEqual([6, 18]);
+});
+
+test("watershed is deterministic, eight-connected, and labels every pixel", () => {
+  const width = 3;
+  const height = 3;
+  const gradient = new Uint8Array([
+    0, 255, 0,
+    255, 255, 255,
+    0, 255, 0,
+  ]);
+  const markers = Uint32Array.from([0, 8]);
+  const first = watershed(gradient, width, height, markers);
+  const second = watershed(gradient, width, height, markers);
+
+  expect(Array.from(first.labels)).toEqual(Array.from(second.labels));
+  expect(Array.from(first.labels)).toEqual([
+    1, 1, 1,
+    1, 1, 2,
+    1, 2, 2,
+  ]);
+  expect(first.regionCount).toBe(2);
+  expect(Array.from(first.labels).every((label) => label > 0)).toBe(true);
+  // The center is reachable diagonally from the first marker at the same level.
+  expect(first.labels[4]).toBe(1);
+});
+
+test("watershed handles 1x1 and an empty marker list", () => {
+  const result = watershed(new Uint8Array([0]), 1, 1, new Uint32Array(0));
+  expect(result.regionCount).toBe(1);
+  expect(Array.from(result.labels)).toEqual([1]);
+});
+
+test("region colorization uses source RGB means and preserves alpha", () => {
+  const source = new Uint8ClampedArray([
+    10, 20, 30, 40,
+    30, 40, 50, 60,
+    100, 110, 120, 130,
+  ]);
+  const output = colorizeRegions(
+    source,
+    Uint32Array.from([1, 1, 2]),
+    3,
+    1,
+    2,
+  );
+  expect(Array.from(output)).toEqual([
+    20, 30, 40, 40,
+    20, 30, 40, 60,
+    100, 110, 120, 130,
+  ]);
+});
+
+test("full single-image pipeline is reproducible on an odd-sized fixture", () => {
+  const width = 17;
+  const height = 13;
+  const source = rgba(width, height, (x, y) => [
+    (x * 17 + y * 3) % 256,
+    (x * 5 + y * 19) % 256,
+    (x * 11 + y * 7) % 256,
+    (x + y) % 2 === 0 ? 255 : 180,
+  ]);
+  const options = {
+    blurRadius: 2,
+    markerBudget: 12,
+    spacing: { face: 1, body: 1, background: 1 },
+  };
+  const first = runRotoscope(source, width, height, options);
+  const second = runRotoscope(source, width, height, options);
+
+  expect(first.mode).toBe("single-image");
+  expect(first.markerCount).toBeGreaterThan(0);
+  expect(Array.from(first.pixels)).toEqual(Array.from(second.pixels));
+  for (let index = 3; index < source.length; index += 4) {
+    expect(first.pixels[index]).toBe(source[index]);
+  }
+});
+
+test("full flat pipeline matches the exact one-region golden output", () => {
+  const source = rgba(3, 1, (x) => {
+    const value = x * 100;
+    return [value, value, value, 100 + x];
+  });
+  const result = runRotoscope(source, 3, 1, {
+    blurRadius: 1,
+    markerBudget: 1,
+  });
+  expect(result.markerCount).toBe(1);
+  expect(Array.from(result.pixels)).toEqual([
+    100, 100, 100, 100,
+    100, 100, 100, 101,
+    100, 100, 100, 102,
+  ]);
+});

--- a/portfolio/components/home/Rotoscope/algorithm.ts
+++ b/portfolio/components/home/Rotoscope/algorithm.ts
@@ -631,12 +631,6 @@ export const watershed = (
     }
   }
 
-  // Defensive completion for malformed or unexpectedly disconnected input.
-  if (visited < count) {
-    for (let index = 0; index < count; index += 1) {
-      if (labels[index] === 0) labels[index] = 1;
-    }
-  }
   return { labels, regionCount };
 };
 

--- a/portfolio/components/home/Rotoscope/algorithm.ts
+++ b/portfolio/components/home/Rotoscope/algorithm.ts
@@ -1,0 +1,722 @@
+/**
+ * Scalar reference for the browser rotoscope.
+ *
+ * The 2017 MATLAB implementation and paper are the semantic source of truth:
+ * background difference -> Shi-Tomasi features -> marker-controlled watershed
+ * -> one mean source color per region. This browser adaptation changes only the
+ * first stage: a blurred copy of a single still stands in for the clean
+ * background frame used by the paper.
+ *
+ * The stage structure is canonical, while two numerical kernels are deliberate
+ * browser approximations: an integer 3x3 Sobel replaces the MATLAB Gaussian
+ * derivative at sigma 0.6, and a 3x3 tensor window replaces its 7x7 window.
+ * Those bounded changes materially reduce work at display resolution and are
+ * frozen by golden fixtures below the stage APIs.
+ *
+ * This implementation intentionally favors readability and deterministic test
+ * fixtures. The WebAssembly implementation is required to match its observable
+ * stage behavior.
+ */
+
+export const MAX_ROTOSCOPE_DIMENSION = 2048;
+export const MAX_ROTOSCOPE_PIXELS = 1024 * 1024;
+
+export type FocusTierName = "face" | "body" | "background";
+
+export type NormalizedPoint = readonly [x: number, y: number];
+
+export interface FocusGeometry {
+  face: {
+    centerX: number;
+    centerY: number;
+    radiusX: number;
+    radiusY: number;
+  };
+  /** Polygon points in normalized image coordinates. */
+  body: readonly NormalizedPoint[];
+}
+
+export interface TierValues {
+  face: number;
+  body: number;
+  background: number;
+}
+
+export interface RotoscopeOptions {
+  /** Radius of the low-frequency box blur used by single-image mode. */
+  blurRadius: number;
+  markerBudget: number;
+  /** Fractional marker allocation. Values are normalized at runtime. */
+  quotas: TierValues;
+  /** Manhattan suppression radius per focus tier. */
+  spacing: TierValues;
+  focus: FocusGeometry;
+}
+
+export interface DifferenceStage {
+  gray: Uint8Array;
+  difference: Uint8Array;
+}
+
+export interface GradientStage {
+  x: Int16Array;
+  y: Int16Array;
+  magnitude: Uint8Array;
+}
+
+export interface SelectedMarkers {
+  indices: Uint32Array;
+  tierCounts: Record<FocusTierName, number>;
+}
+
+export interface WatershedResult {
+  labels: Uint32Array;
+  regionCount: number;
+}
+
+export interface RotoscopeResult {
+  pixels: Uint8ClampedArray;
+  markerCount: number;
+  tierCounts: Record<FocusTierName, number>;
+  mode: "single-image";
+}
+
+const DEFAULT_FOCUS: FocusGeometry = {
+  face: {
+    centerX: 0.4,
+    centerY: 0.56,
+    radiusX: 0.14,
+    radiusY: 0.27,
+  },
+  body: [
+    [0.31, 0.67],
+    [0.53, 0.66],
+    [0.75, 0.82],
+    [0.8, 1],
+    [0, 1],
+    [0, 0.84],
+    [0.26, 0.72],
+  ],
+};
+
+export const DEFAULT_ROTOSCOPE_OPTIONS: Readonly<RotoscopeOptions> = {
+  blurRadius: 9,
+  markerBudget: 480,
+  quotas: { face: 0.5, body: 0.3, background: 0.2 },
+  spacing: { face: 3, body: 5, background: 8 },
+  focus: DEFAULT_FOCUS,
+};
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.min(high, Math.max(low, value));
+
+const finiteOr = (value: number, fallback: number): number =>
+  Number.isFinite(value) ? value : fallback;
+
+const checkedPixelCount = (width: number, height: number): number => {
+  if (
+    !Number.isInteger(width) ||
+    !Number.isInteger(height) ||
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_ROTOSCOPE_DIMENSION ||
+    height > MAX_ROTOSCOPE_DIMENSION
+  ) {
+    throw new RangeError("invalid rotoscope dimensions");
+  }
+  const count = width * height;
+  if (!Number.isSafeInteger(count) || count > MAX_ROTOSCOPE_PIXELS) {
+    throw new RangeError("rotoscope image exceeds the pixel limit");
+  }
+  return count;
+};
+
+export const validateRgba = (
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+): number => {
+  const count = checkedPixelCount(width, height);
+  if (pixels.length !== count * 4) {
+    throw new RangeError("RGBA byte length does not match the dimensions");
+  }
+  return count;
+};
+
+const normalizedOptions = (
+  options: Partial<RotoscopeOptions>,
+  pixelCount: number,
+): RotoscopeOptions => {
+  const quotas = options.quotas ?? DEFAULT_ROTOSCOPE_OPTIONS.quotas;
+  const spacing = options.spacing ?? DEFAULT_ROTOSCOPE_OPTIONS.spacing;
+  const focus = options.focus ?? DEFAULT_ROTOSCOPE_OPTIONS.focus;
+  let faceQuota = Math.max(0, finiteOr(quotas.face, 0));
+  let bodyQuota = Math.max(0, finiteOr(quotas.body, 0));
+  let backgroundQuota = Math.max(0, finiteOr(quotas.background, 0));
+  let quotaSum = faceQuota + bodyQuota + backgroundQuota;
+  if (quotaSum <= 0) {
+    faceQuota = DEFAULT_ROTOSCOPE_OPTIONS.quotas.face;
+    bodyQuota = DEFAULT_ROTOSCOPE_OPTIONS.quotas.body;
+    backgroundQuota = DEFAULT_ROTOSCOPE_OPTIONS.quotas.background;
+    quotaSum = faceQuota + bodyQuota + backgroundQuota;
+  }
+
+  return {
+    blurRadius: clamp(
+      Math.round(
+        finiteOr(options.blurRadius ?? DEFAULT_ROTOSCOPE_OPTIONS.blurRadius, 9),
+      ),
+      1,
+      64,
+    ),
+    markerBudget: clamp(
+      Math.round(
+        finiteOr(
+          options.markerBudget ?? DEFAULT_ROTOSCOPE_OPTIONS.markerBudget,
+          480,
+        ),
+      ),
+      1,
+      pixelCount,
+    ),
+    quotas: {
+      face: faceQuota / quotaSum,
+      body: bodyQuota / quotaSum,
+      background: backgroundQuota / quotaSum,
+    },
+    spacing: {
+      face: clamp(Math.round(finiteOr(spacing.face, 3)), 1, 64),
+      body: clamp(Math.round(finiteOr(spacing.body, 5)), 1, 64),
+      background: clamp(
+        Math.round(finiteOr(spacing.background, 8)),
+        1,
+        64,
+      ),
+    },
+    focus,
+  };
+};
+
+const boxBlur = (
+  source: Uint8Array,
+  width: number,
+  height: number,
+  radius: number,
+): Uint8Array => {
+  const count = width * height;
+  const horizontal = new Uint16Array(count);
+  const output = new Uint8Array(count);
+
+  for (let y = 0; y < height; y += 1) {
+    const row = y * width;
+    let sum = 0;
+    let right = Math.min(width - 1, radius);
+    for (let x = 0; x <= right; x += 1) sum += source[row + x];
+
+    for (let x = 0; x < width; x += 1) {
+      const left = Math.max(0, x - radius);
+      right = Math.min(width - 1, x + radius);
+      horizontal[row + x] = Math.round(sum / (right - left + 1));
+      const remove = x - radius;
+      const add = x + radius + 1;
+      if (remove >= 0) sum -= source[row + remove];
+      if (add < width) sum += source[row + add];
+    }
+  }
+
+  for (let x = 0; x < width; x += 1) {
+    let sum = 0;
+    let bottom = Math.min(height - 1, radius);
+    for (let y = 0; y <= bottom; y += 1) sum += horizontal[y * width + x];
+
+    for (let y = 0; y < height; y += 1) {
+      const top = Math.max(0, y - radius);
+      bottom = Math.min(height - 1, y + radius);
+      output[y * width + x] = Math.round(sum / (bottom - top + 1));
+      const remove = y - radius;
+      const add = y + radius + 1;
+      if (remove >= 0) sum -= horizontal[remove * width + x];
+      if (add < height) sum += horizontal[add * width + x];
+    }
+  }
+
+  return output;
+};
+
+export const grayscaleAndDifference = (
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+  blurRadius: number,
+): DifferenceStage => {
+  const count = validateRgba(pixels, width, height);
+  const gray = new Uint8Array(count);
+  for (let index = 0, offset = 0; index < count; index += 1, offset += 4) {
+    // Integer Rec. 601 weights; deterministic in JS and Wasm.
+    gray[index] =
+      (77 * pixels[offset] +
+        150 * pixels[offset + 1] +
+        29 * pixels[offset + 2] +
+        128) >>
+      8;
+  }
+
+  const safeBlurRadius = clamp(
+    Math.round(finiteOr(blurRadius, DEFAULT_ROTOSCOPE_OPTIONS.blurRadius)),
+    1,
+    64,
+  );
+  const blurred = boxBlur(gray, width, height, safeBlurRadius);
+  const difference = new Uint8Array(count);
+  for (let index = 0; index < count; index += 1) {
+    difference[index] = Math.abs(gray[index] - blurred[index]);
+  }
+  return { gray, difference };
+};
+
+export const sobelGradient = (
+  source: Uint8Array,
+  width: number,
+  height: number,
+): GradientStage => {
+  const count = checkedPixelCount(width, height);
+  if (source.length !== count) throw new RangeError("source length mismatch");
+
+  const xGradient = new Int16Array(count);
+  const yGradient = new Int16Array(count);
+  const magnitude = new Uint8Array(count);
+  for (let y = 1; y < height - 1; y += 1) {
+    const row = y * width;
+    for (let x = 1; x < width - 1; x += 1) {
+      const index = row + x;
+      const topLeft = source[index - width - 1];
+      const top = source[index - width];
+      const topRight = source[index - width + 1];
+      const left = source[index - 1];
+      const right = source[index + 1];
+      const bottomLeft = source[index + width - 1];
+      const bottom = source[index + width];
+      const bottomRight = source[index + width + 1];
+      const gx =
+        -topLeft + topRight - 2 * left + 2 * right - bottomLeft + bottomRight;
+      const gy =
+        -topLeft - 2 * top - topRight + bottomLeft + 2 * bottom + bottomRight;
+      xGradient[index] = gx;
+      yGradient[index] = gy;
+      magnitude[index] = Math.min(255, (Math.abs(gx) + Math.abs(gy) + 2) >> 2);
+    }
+  }
+  return { x: xGradient, y: yGradient, magnitude };
+};
+
+export const minimumEigenvalue = (a: number, b: number, c: number): number => {
+  const trace = a + c;
+  const discriminant = Math.sqrt((a - c) * (a - c) + 4 * b * b);
+  return Math.max(0, (trace - discriminant) * 0.5);
+};
+
+export const shiTomasiScores = (
+  difference: Uint8Array,
+  width: number,
+  height: number,
+): Float32Array => {
+  const gradients = sobelGradient(difference, width, height);
+  const count = width * height;
+  const scores = new Float32Array(count);
+
+  for (let y = 2; y < height - 2; y += 1) {
+    for (let x = 2; x < width - 2; x += 1) {
+      let xx = 0;
+      let xy = 0;
+      let yy = 0;
+      for (let dy = -1; dy <= 1; dy += 1) {
+        let index = (y + dy) * width + x - 1;
+        for (let dx = -1; dx <= 1; dx += 1, index += 1) {
+          const gx = gradients.x[index];
+          const gy = gradients.y[index];
+          xx += gx * gx;
+          xy += gx * gy;
+          yy += gy * gy;
+        }
+      }
+      scores[y * width + x] = minimumEigenvalue(xx, xy, yy);
+    }
+  }
+  return scores;
+};
+
+const pointInPolygon = (
+  normalizedX: number,
+  normalizedY: number,
+  polygon: readonly NormalizedPoint[],
+): boolean => {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const [xi, yi] = polygon[i];
+    const [xj, yj] = polygon[j];
+    const intersects =
+      yi > normalizedY !== yj > normalizedY &&
+      normalizedX <
+        ((xj - xi) * (normalizedY - yi)) / (yj - yi || Number.EPSILON) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+};
+
+export const classifyFocusTier = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  focus: FocusGeometry,
+): FocusTierName => {
+  const normalizedX = (x + 0.5) / width;
+  const normalizedY = (y + 0.5) / height;
+  const faceX =
+    (normalizedX - focus.face.centerX) / Math.max(0.0001, focus.face.radiusX);
+  const faceY =
+    (normalizedY - focus.face.centerY) / Math.max(0.0001, focus.face.radiusY);
+  if (faceX * faceX + faceY * faceY <= 1) return "face";
+  if (pointInPolygon(normalizedX, normalizedY, focus.body)) return "body";
+  return "background";
+};
+
+const tierQuota = (
+  budget: number,
+  quotas: TierValues,
+): Record<FocusTierName, number> => {
+  const names: readonly FocusTierName[] = ["face", "body", "background"];
+  const exact = names.map((name) => budget * quotas[name]);
+  const allocated = exact.map(Math.floor);
+  let remaining = budget - allocated.reduce((sum, value) => sum + value, 0);
+  const remainderOrder = names
+    .map((name, index) => ({ index, name, remainder: exact[index] - allocated[index] }))
+    .sort((left, right) => right.remainder - left.remainder || left.index - right.index);
+  for (let index = 0; index < remainderOrder.length && remaining > 0; index += 1) {
+    allocated[remainderOrder[index].index] += 1;
+    remaining -= 1;
+  }
+  return {
+    face: allocated[0],
+    body: allocated[1],
+    background: allocated[2],
+  };
+};
+
+const isLocalMaximum = (
+  scores: Float32Array,
+  index: number,
+  width: number,
+): boolean => {
+  const score = scores[index];
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) continue;
+      const neighbor = index + dy * width + dx;
+      const neighborScore = scores[neighbor];
+      if (neighborScore > score || (neighborScore === score && neighbor < index)) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+const blockDiamond = (
+  blocked: Uint8Array,
+  index: number,
+  width: number,
+  height: number,
+  radius: number,
+): void => {
+  const centerY = Math.floor(index / width);
+  const centerX = index - centerY * width;
+  for (let dy = -radius; dy <= radius; dy += 1) {
+    const y = centerY + dy;
+    if (y < 0 || y >= height) continue;
+    const horizontal = radius - Math.abs(dy);
+    for (let dx = -horizontal; dx <= horizontal; dx += 1) {
+      const x = centerX + dx;
+      if (x >= 0 && x < width) blocked[y * width + x] = 1;
+    }
+  }
+};
+
+const candidatesForTier = (
+  tier: FocusTierName,
+  scores: Float32Array,
+  width: number,
+  height: number,
+  focus: FocusGeometry,
+  spacing: number,
+): number[] => {
+  const count = width * height;
+  const seen = new Uint8Array(count);
+  const candidates: number[] = [];
+
+  // Strong local maxima preserve the Shi-Tomasi ranking.
+  for (let y = 2; y < height - 2; y += 1) {
+    for (let x = 2; x < width - 2; x += 1) {
+      const index = y * width + x;
+      if (
+        scores[index] > 0 &&
+        classifyFocusTier(x, y, width, height, focus) === tier &&
+        isLocalMaximum(scores, index, width)
+      ) {
+        candidates.push(index);
+        seen[index] = 1;
+      }
+    }
+  }
+
+  // A best candidate per spatial cell guarantees useful coverage on smooth or
+  // low-contrast tiers without allowing a busy background to take the budget.
+  const cell = Math.max(2, spacing);
+  for (let tileY = 0; tileY < height; tileY += cell) {
+    for (let tileX = 0; tileX < width; tileX += cell) {
+      let bestIndex = -1;
+      let bestScore = -1;
+      const yEnd = Math.min(height, tileY + cell);
+      const xEnd = Math.min(width, tileX + cell);
+      for (let y = tileY; y < yEnd; y += 1) {
+        for (let x = tileX; x < xEnd; x += 1) {
+          if (classifyFocusTier(x, y, width, height, focus) !== tier) continue;
+          const index = y * width + x;
+          const score = scores[index];
+          if (score > bestScore || (score === bestScore && index < bestIndex)) {
+            bestIndex = index;
+            bestScore = score;
+          }
+        }
+      }
+      if (bestIndex >= 0 && seen[bestIndex] === 0) {
+        candidates.push(bestIndex);
+        seen[bestIndex] = 1;
+      }
+    }
+  }
+
+  candidates.sort((left, right) => scores[right] - scores[left] || left - right);
+  return candidates;
+};
+
+export const selectMarkers = (
+  scores: Float32Array,
+  width: number,
+  height: number,
+  options: Partial<RotoscopeOptions> = {},
+): SelectedMarkers => {
+  const count = checkedPixelCount(width, height);
+  if (scores.length !== count) throw new RangeError("score length mismatch");
+  const normalized = normalizedOptions(options, count);
+  const quotas = tierQuota(normalized.markerBudget, normalized.quotas);
+  const blocked = new Uint8Array(count);
+  const markers: number[] = [];
+  const tierCounts: Record<FocusTierName, number> = {
+    face: 0,
+    body: 0,
+    background: 0,
+  };
+  const tiers: readonly FocusTierName[] = ["face", "body", "background"];
+
+  for (const tier of tiers) {
+    const spacing = normalized.spacing[tier];
+    const candidates = candidatesForTier(
+      tier,
+      scores,
+      width,
+      height,
+      normalized.focus,
+      spacing,
+    );
+    for (const index of candidates) {
+      if (tierCounts[tier] >= quotas[tier]) break;
+      if (blocked[index] !== 0) continue;
+      markers.push(index);
+      tierCounts[tier] += 1;
+      blockDiamond(blocked, index, width, height, spacing);
+    }
+  }
+
+  // Degenerate images still need one marker so every pixel is labeled.
+  if (markers.length === 0) {
+    markers.push(Math.floor(count / 2));
+    tierCounts.background = 1;
+  }
+  return { indices: Uint32Array.from(markers), tierCounts };
+};
+
+const enqueue = (
+  index: number,
+  level: number,
+  heads: Int32Array,
+  tails: Int32Array,
+  next: Int32Array,
+): void => {
+  if (heads[level] < 0) heads[level] = index;
+  else next[tails[level]] = index;
+  tails[level] = index;
+};
+
+/**
+ * Deterministic marker-controlled minimum-barrier flood.
+ *
+ * With an 8-bit source-luminance gradient, the 256 FIFO buckets are a radix
+ * priority queue. Each pixel is discovered once in non-decreasing barrier
+ * order, which is equivalent to multi-source watershed flooding with stable
+ * seed and neighbor tie order.
+ */
+export const watershed = (
+  gradient: Uint8Array,
+  width: number,
+  height: number,
+  markerIndices: Uint32Array,
+): WatershedResult => {
+  const count = checkedPixelCount(width, height);
+  if (gradient.length !== count) throw new RangeError("gradient length mismatch");
+  if (markerIndices.length > count) throw new RangeError("too many markers");
+
+  const labels = new Uint32Array(count);
+  const queued = new Uint8Array(count);
+  const next = new Int32Array(count);
+  next.fill(-1);
+  const heads = new Int32Array(256);
+  const tails = new Int32Array(256);
+  heads.fill(-1);
+  tails.fill(-1);
+  let regionCount = 0;
+
+  for (let marker = 0; marker < markerIndices.length; marker += 1) {
+    const index = markerIndices[marker];
+    if (index >= count || queued[index] !== 0) continue;
+    regionCount += 1;
+    labels[index] = regionCount;
+    queued[index] = 1;
+    enqueue(index, 0, heads, tails, next);
+  }
+  if (regionCount === 0) {
+    const center = Math.floor(count / 2);
+    regionCount = 1;
+    labels[center] = 1;
+    queued[center] = 1;
+    enqueue(center, 0, heads, tails, next);
+  }
+
+  const neighborX = [-1, 0, 1, -1, 1, -1, 0, 1] as const;
+  const neighborY = [-1, -1, -1, 0, 0, 1, 1, 1] as const;
+  let level = 0;
+  let visited = regionCount;
+  while (visited < count) {
+    while (level < 256 && heads[level] < 0) level += 1;
+    if (level >= 256) break;
+    const index = heads[level];
+    heads[level] = next[index];
+    if (heads[level] < 0) tails[level] = -1;
+    next[index] = -1;
+    const y = Math.floor(index / width);
+    const x = index - y * width;
+    const label = labels[index];
+
+    for (let neighbor = 0; neighbor < 8; neighbor += 1) {
+      const nx = x + neighborX[neighbor];
+      const ny = y + neighborY[neighbor];
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+      const nextIndex = ny * width + nx;
+      if (queued[nextIndex] !== 0) continue;
+      queued[nextIndex] = 1;
+      labels[nextIndex] = label;
+      visited += 1;
+      const nextLevel = Math.max(level, gradient[nextIndex]);
+      enqueue(nextIndex, nextLevel, heads, tails, next);
+    }
+  }
+
+  // Defensive completion for malformed or unexpectedly disconnected input.
+  if (visited < count) {
+    for (let index = 0; index < count; index += 1) {
+      if (labels[index] === 0) labels[index] = 1;
+    }
+  }
+  return { labels, regionCount };
+};
+
+export const colorizeRegions = (
+  source: Uint8ClampedArray,
+  labels: Uint32Array,
+  width: number,
+  height: number,
+  regionCount: number,
+): Uint8ClampedArray => {
+  const count = validateRgba(source, width, height);
+  if (labels.length !== count) throw new RangeError("label length mismatch");
+  if (!Number.isInteger(regionCount) || regionCount <= 0 || regionCount > count) {
+    throw new RangeError("invalid region count");
+  }
+  const red = new Uint32Array(regionCount + 1);
+  const green = new Uint32Array(regionCount + 1);
+  const blue = new Uint32Array(regionCount + 1);
+  const population = new Uint32Array(regionCount + 1);
+
+  for (let index = 0, offset = 0; index < count; index += 1, offset += 4) {
+    const label = labels[index];
+    if (label === 0 || label > regionCount) continue;
+    red[label] += source[offset];
+    green[label] += source[offset + 1];
+    blue[label] += source[offset + 2];
+    population[label] += 1;
+  }
+
+  const output = new Uint8ClampedArray(source.length);
+  for (let index = 0, offset = 0; index < count; index += 1, offset += 4) {
+    const label = labels[index];
+    const size = label <= regionCount ? population[label] : 0;
+    if (size > 0) {
+      output[offset] = Math.round(red[label] / size);
+      output[offset + 1] = Math.round(green[label] / size);
+      output[offset + 2] = Math.round(blue[label] / size);
+    } else {
+      output[offset] = source[offset];
+      output[offset + 1] = source[offset + 1];
+      output[offset + 2] = source[offset + 2];
+    }
+    output[offset + 3] = source[offset + 3];
+  }
+  return output;
+};
+
+export const runRotoscope = (
+  source: Uint8ClampedArray,
+  width: number,
+  height: number,
+  options: Partial<RotoscopeOptions> = {},
+): RotoscopeResult => {
+  const count = validateRgba(source, width, height);
+  const normalized = normalizedOptions(options, count);
+  const difference = grayscaleAndDifference(
+    source,
+    width,
+    height,
+    normalized.blurRadius,
+  );
+  const scores = shiTomasiScores(difference.difference, width, height);
+  const selected = selectMarkers(scores, width, height, normalized);
+  const watershedGradient = sobelGradient(difference.gray, width, height).magnitude;
+  const segmented = watershed(
+    watershedGradient,
+    width,
+    height,
+    selected.indices,
+  );
+  return {
+    pixels: colorizeRegions(
+      source,
+      segmented.labels,
+      width,
+      height,
+      segmented.regionCount,
+    ),
+    markerCount: segmented.regionCount,
+    tierCounts: selected.tierCounts,
+    mode: "single-image",
+  };
+};


### PR DESCRIPTION
## TL;DR

Readable scalar oracle for the 2017 best-features rotoscope, adapted to a single still via a blurred-copy difference. Golden fixtures freeze stage and full-pipeline bytes. This is 1 of the Track B stack; homepage, Wasm, and lab stay out.

## Type of Change

- [x] New feature
- [x] Refactoring (follow-up: drop unreachable watershed fill)

## Which Package(s) are Affected?

- [x] Portfolio (TypeScript/Next.js)

## How to review

Read `algorithm.ts` top-to-bottom as the contract later PRs must match byte-for-byte.

| Layer | Files | Why |
| --- | --- | --- |
| Core | `portfolio/components/home/Rotoscope/algorithm.ts` | Difference → Shi–Tomasi → quotas → 8-neighbor flood → mean color |
| Tests | `portfolio/components/home/Rotoscope/algorithm.test.ts` | Exact stage fixtures, quota math, watershed determinism |
| Docs | `portfolio/components/home/Rotoscope/README.md` | Paper canonical; Sobel 3×3 and 3×3 tensor are deliberate |

## Commits

1. `add deterministic rotoscope reference engine` — oracle + fixtures
2. `refactor(rotoscope): drop unreachable watershed label fill` — deslop only; no fixture change

History is two additive commits; not rewritten. Default quotas remain `{ face: 0.5, body: 0.3, background: 0.2 }`. Portrait 55/30/15 lives in #1440 `portraitConfig.ts`.

## What simplify / deslop removed

- Watershed defensive completion loop that labeled leftover pixels as region 1. On an 8-connected rectangular grid the flood already visits every pixel; fixtures already require `label > 0`.
- Left the file header, Rec. 601 comment, and marker-pass comments: they document the Wasm contract and the two ranking passes.

## Testing

- [x] `npx jest --runInBand components/home/Rotoscope/algorithm.test.ts`
- [x] ESLint on the engine files
- [x] `npx tsc --noEmit`

## Review risks

- Later Wasm (#1441) must stay byte-exact with this oracle. Do not simplify numeric kernels here without updating fixtures and the AssemblyScript port together.
- `Partial<RotoscopeOptions>` still normalizes non-finite public inputs; that is covered by tests, not slop.

## Related

Followed by #1440 (homepage worker) and #1441 (Wasm). Explainer is independent #1443.
