### PR TITLE
chore(deps): remove vestigial @babel/plugin-syntax-flow devDependency

### DIFF
--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -18,7 +18,6 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
-        "@babel/plugin-syntax-flow": "^7.29.7",
         "@jest/types": "^30.0.0",
         "@lhci/cli": "^0.15.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -325,22 +324,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
-      "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -64,7 +64,6 @@
     "lodash-es": ">=4.17.23"
   },
   "devDependencies": {
-    "@babel/plugin-syntax-flow": "^7.29.7",
     "@jest/types": "^30.0.0",
     "@lhci/cli": "^0.15.1",
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Replaces #1446 (babel 7→8 major bump), which cannot install: `@babel/plugin-syntax-flow@8.0.1` peer-requires `@babel/core@^8`, but the jest 30 toolchain locks the tree to babel-core 7.x, so `npm ci` fails with ERESOLVE.

The dependency itself is vestigial — added in the CRA era (`dd3190521`), and today:
- no `babel.config.*` / `.babelrc*` exists anywhere in the repo
- `jest.config.js` has no babel transform; Next.js compiles via SWC
- nothing else in the lockfile depends on the plugin (pure 18-line deletion)

Verified locally: `npm ci` exit 0, jest 71/71 suites (395/395 tests), `tsc --noEmit` clean.

Merging this removes the manifest entry, so dependabot will close #1446 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)