### PR TITLE
chore(ci): ignore pyspark in dependabot — pin mirrors EMR Serverless runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      # pyspark deliberately mirrors EMR_SPARK_RELEASE/EMR_SPARK_VERSION in
+      # infra/components/emr_serverless_runtime.py (parity enforced by
+      # infra/components/test_emr_serverless_runtime.py). Bump all three
+      # together when AWS ships an EMR Serverless label with a newer Spark.
+      - dependency-name: "pyspark"
 
   # Monitor base-image tags in Dockerfiles throughout the repository.
   - package-ecosystem: "docker"


### PR DESCRIPTION
Companion to closing #1453. The `pyspark==4.0.2` pin in `receipt_langsmith` deliberately mirrors `EMR_SPARK_RELEASE = "emr-spark-8.0.0"` (Spark 4.0.2) in `infra/components/emr_serverless_runtime.py`, and `test_emr_serverless_runtime.py` asserts the two stay equal — so dependabot pyspark bumps can never merge green until AWS ships a newer EMR Serverless Spark label (none with 4.1/4.2 exists today). This tells dependabot to stop proposing them; when a new label ships, bump the runtime constants, parity test, and pin together in one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)