### PR TITLE
chore(ci): ignore mcp majors and torch bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,17 @@ updates:
       # infra/components/test_emr_serverless_runtime.py). Bump all three
       # together when AWS ships an EMR Serverless label with a newer Spark.
       - dependency-name: "pyspark"
+      # mcp is pinned <2: receipt_logo/receipt_logo/mcp_server.py and
+      # scripts/receipt_mcp_server.py use the mcp 1.x low-level Server API,
+      # which breaks under the mcp 2.x rework. Drop after migrating both
+      # servers to the v2 API.
+      - dependency-name: "mcp"
+        update-types: ["version-update:semver-major"]
+      # torch is capped <=2.7.0 in receipt_layoutlm: coremltools 9.0 (latest)
+      # validates PyTorch only through 2.7.0 and the [coreml] extra has no
+      # torch pin of its own. Raise the cap only alongside a coremltools
+      # release that certifies a newer torch.
+      - dependency-name: "torch"
 
   # Monitor base-image tags in Dockerfiles throughout the repository.
   - package-ecosystem: "docker"


### PR DESCRIPTION
Companion to closing #1463 and #1462 — both bumps fight deliberate pins:

- **mcp majors ignored**: `receipt_logo/receipt_logo/mcp_server.py` and `scripts/receipt_mcp_server.py` use the mcp 1.x low-level `Server` API (list_tools/call_tool handler shapes), which the mcp 2.0 rework breaks. Official guidance: pin `<2` until migrated; 1.x still receives security fixes. Minor/patch 1.x updates still flow.
- **torch ignored**: the `<=2.7.0` cap in `receipt_layoutlm` exists because coremltools 9.0 (still the latest) validates PyTorch only through 2.7.0, and the `[coreml]` extra carries no torch pin — a wider cap would let the export-worker venv resolve torch 2.13 alongside coremltools 9.0 and break CoreML export. Raise the cap together with a coremltools release that certifies newer torch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)