### PR TITLE
Fix Chroma query-embedding quota + Swift AMOUNT filter killing financial labels (#1466)

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -353,6 +353,31 @@ upload_images = UploadImages(
     summary_queue_arn=chromadb_infrastructure.chromadb_queues.summary_queue_arn,
 )
 
+# Section KNN verification failures are swallowed per-receipt so the drain
+# continues, which let #1466 (Chroma 20-embedding query quota) strip section
+# verification from every ingest for a week with green pipelines. The upload
+# handler emits UploadLambdaSectionVerificationError (EMF, EmbeddingWorkflow
+# namespace) per receipt; any error is worth a notification.
+upload_section_verification_alarm = aws.cloudwatch.MetricAlarm(
+    "upload-section-verification-error",
+    alarm_description=(
+        "Upload pipeline Section KNN verification is erroring (e.g. Chroma "
+        "Cloud quota/outage) - receipts are ingesting without verified "
+        "sections and product/financial labeling degrades silently."
+    ),
+    metric_name="UploadLambdaSectionVerificationError",
+    namespace="EmbeddingWorkflow",
+    statistic="Sum",
+    period=300,
+    evaluation_periods=1,
+    threshold=0,
+    comparison_operator="GreaterThanThreshold",
+    alarm_actions=[notification_system.critical_error_topic_arn],
+    ok_actions=[notification_system.critical_error_topic_arn],
+    treat_missing_data="notBreaching",
+    tags={"environment": stack},
+)
+
 pulumi.export("ocr_job_queue_url", upload_images.ocr_queue.url)
 pulumi.export("ocr_results_queue_url", upload_images.ocr_results_queue.url)
 pulumi.export(

--- a/infra/upload_images/container_ocr/handler/handler.py
+++ b/infra/upload_images/container_ocr/handler/handler.py
@@ -241,6 +241,12 @@ def _emit_section_observability(
                 "verification_abstained_count"
             ),
         }
+        # Emitted only when Section KNN verification errored (e.g. Chroma
+        # quota/outage). The failure is swallowed upstream so the drain
+        # continues — this metric is the only alarmable signal that receipts
+        # are ingesting without verified sections (#1466).
+        if embedding_result.get("verification_error"):
+            metric_map["UploadLambdaSectionVerificationError"] = 1
         row_source = embedding_result.get("row_source")
         if row_source is not None:
             # 1 when ingest did not persist rows and the lines pipeline fell

--- a/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
+++ b/infra/upload_images/container_ocr/handler/tests/test_swift_payload_contract.py
@@ -789,6 +789,35 @@ def test_section_observability_flags_reconstructed_rows(monkeypatch):
     assert "UploadLambdaSectionsProposed" not in metrics
 
 
+def test_section_observability_emits_verification_error_metric(monkeypatch):
+    from handler import handler as handler_module
+
+    recorder = _MetricsRecorder()
+    monkeypatch.setattr(handler_module, "emf_metrics", recorder)
+
+    # A swallowed verification failure (#1466: Chroma query-embedding quota)
+    # must surface as an alarmable metric, not just a properties field.
+    handler_module._emit_section_observability(
+        IMAGE_ID,
+        1,
+        {
+            "row_count": 39,
+            "row_source": "persisted",
+            "section_proposed_count": 0,
+            "verification_error": "Quota exceeded: Number of query embeddings",
+        },
+    )
+
+    metrics = recorder.calls[0]["metrics"]
+    assert metrics["UploadLambdaSectionVerificationError"] == 1.0
+    # Successful runs must NOT emit the metric (exact-match test above
+    # covers absence); the error string still travels as a property.
+    assert (
+        recorder.calls[0]["properties"]["verification_error"]
+        == "Quota exceeded: Number of query embeddings"
+    )
+
+
 def test_section_observability_is_silent_without_stats(monkeypatch):
     from handler import handler as handler_module
 

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -214,6 +214,39 @@ def _retry_with_backoff(
     raise last_exc  # type: ignore[misc]
 
 
+# Chroma Cloud rejects Query calls with more than 20 query embeddings
+# ("Quota exceeded: 'Number of query embeddings'"), so larger batches must
+# be split into sequential requests and their results merged.
+MAX_QUERY_EMBEDDINGS = 20
+
+
+def _merge_query_results(
+    results: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Concatenate per-query result lists from chunked query calls.
+
+    Chroma query results carry one outer entry per query embedding in keys
+    like ``ids``/``distances``/``metadatas``/``embeddings``/``documents``;
+    merging preserves query order. Non-sequence values (and ``included``,
+    which is identical across chunks) are taken from the first chunk.
+    """
+    if len(results) == 1:
+        return results[0]
+    merged: Dict[str, Any] = {}
+    for result in results:
+        for key, value in result.items():
+            if key == "included" or value is None:
+                merged.setdefault(key, value)
+                continue
+            # list(...) also normalizes numpy arrays of per-query rows
+            chunk_rows = list(value)
+            if isinstance(merged.get(key), list):
+                merged[key].extend(chunk_rows)
+            else:
+                merged[key] = chunk_rows
+    return merged
+
+
 class ChromaCollection(Protocol):
     """Protocol for ChromaDB collection interface.
 
@@ -759,6 +792,10 @@ class ChromaClient:
         """
         Query vectors from a collection.
 
+        Batches of more than MAX_QUERY_EMBEDDINGS embeddings are split into
+        sequential requests and the per-query result lists concatenated, so
+        callers see one result regardless of batch size.
+
         Args:
             collection_name: Name of the collection
             query_embeddings: Optional query embedding vectors
@@ -780,21 +817,30 @@ class ChromaClient:
         if where:
             query_args["where"] = where
 
-        if query_embeddings is not None:
-            query_args["query_embeddings"] = query_embeddings
-        elif query_texts is not None:
-            if self.mode == "read":
-                raise ValueError(
-                    "Text queries require write mode with embedding function"
-                )
-            query_args["query_texts"] = query_texts
-        else:
+        if query_embeddings is None and query_texts is None:
             raise ValueError(
                 "Either query_embeddings or query_texts must be provided"
             )
+        if query_embeddings is None and self.mode == "read":
+            raise ValueError(
+                "Text queries require write mode with embedding function"
+            )
 
-        result = _retry_with_backoff(collection.query, **query_args)
-        return result  # type: ignore[no-any-return]
+        batch_key, batch = (
+            ("query_embeddings", query_embeddings)
+            if query_embeddings is not None
+            else ("query_texts", query_texts)
+        )
+        results = []
+        for start in range(0, len(batch), MAX_QUERY_EMBEDDINGS):
+            chunk_args = dict(query_args)
+            chunk_args[batch_key] = batch[
+                start : start + MAX_QUERY_EMBEDDINGS
+            ]
+            results.append(
+                _retry_with_backoff(collection.query, **chunk_args)
+            )
+        return _merge_query_results(results)
 
     def get(
         self,

--- a/receipt_chroma/receipt_chroma/data/chroma_client.py
+++ b/receipt_chroma/receipt_chroma/data/chroma_client.py
@@ -834,12 +834,8 @@ class ChromaClient:
         results = []
         for start in range(0, len(batch), MAX_QUERY_EMBEDDINGS):
             chunk_args = dict(query_args)
-            chunk_args[batch_key] = batch[
-                start : start + MAX_QUERY_EMBEDDINGS
-            ]
-            results.append(
-                _retry_with_backoff(collection.query, **chunk_args)
-            )
+            chunk_args[batch_key] = batch[start : start + MAX_QUERY_EMBEDDINGS]
+            results.append(_retry_with_backoff(collection.query, **chunk_args))
         return _merge_query_results(results)
 
     def get(

--- a/receipt_chroma/tests/unit/test_chroma_client.py
+++ b/receipt_chroma/tests/unit/test_chroma_client.py
@@ -415,6 +415,71 @@ def test_query_with_embeddings():
 
 
 @pytest.mark.unit
+def test_query_chunks_large_embedding_batches():
+    """Batches above the Chroma Cloud quota are split and results merged.
+
+    Chroma Cloud rejects Query calls with more than 20 query embeddings, which
+    silently stripped section verification and semantic label proposals from
+    every receipt with more than 20 lines/words.
+    """
+    from receipt_chroma.data.chroma_client import MAX_QUERY_EMBEDDINGS
+
+    n_queries = 45
+    embeddings = [[float(i)] for i in range(n_queries)]
+
+    collection = MagicMock()
+
+    def fake_query(**kwargs):
+        chunk = kwargs["query_embeddings"]
+        assert len(chunk) <= MAX_QUERY_EMBEDDINGS
+        return {
+            "ids": [[f"id-{embedding[0]:.0f}"] for embedding in chunk],
+            "distances": [[0.1] for _ in chunk],
+            "metadatas": [[{"source": embedding[0]}] for embedding in chunk],
+            "documents": None,
+            "included": ["metadatas", "distances"],
+        }
+
+    collection.query.side_effect = fake_query
+
+    with ChromaClient(mode="write", metadata_only=True) as client:
+        with patch.object(client, "get_collection", return_value=collection):
+            result = client.query(
+                collection_name="lines",
+                query_embeddings=embeddings,
+                n_results=3,
+            )
+
+    assert collection.query.call_count == 3  # 20 + 20 + 5
+    assert len(result["ids"]) == n_queries
+    assert result["ids"][0] == ["id-0"]
+    assert result["ids"][-1] == ["id-44"]
+    assert len(result["metadatas"]) == n_queries
+    assert result["included"] == ["metadatas", "distances"]
+    assert result["documents"] is None
+
+
+@pytest.mark.unit
+def test_query_small_batch_single_request():
+    """Batches at or below the quota still go out as one request."""
+    from receipt_chroma.data.chroma_client import MAX_QUERY_EMBEDDINGS
+
+    collection = MagicMock()
+    collection.query.return_value = {"ids": [["a"]] * MAX_QUERY_EMBEDDINGS}
+
+    with ChromaClient(mode="write", metadata_only=True) as client:
+        with patch.object(client, "get_collection", return_value=collection):
+            result = client.query(
+                collection_name="lines",
+                query_embeddings=[[0.1]] * MAX_QUERY_EMBEDDINGS,
+                n_results=2,
+            )
+
+    assert collection.query.call_count == 1
+    assert len(result["ids"]) == MAX_QUERY_EMBEDDINGS
+
+
+@pytest.mark.unit
 def test_query_texts_in_read_mode_raises_error():
     """Test that text queries in read mode raise ValueError."""
     # First create collection in write mode

--- a/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptWordLabel.swift
+++ b/receipt_ocr_swift/Sources/ReceiptOCRCore/Models/ReceiptWordLabel.swift
@@ -40,6 +40,19 @@ public struct ReceiptWordLabel: Equatable {
         "WEBSITE",
     ]
 
+    /// Model-emitted labels the cloud pipeline reclassifies rather than
+    /// stores as-is. AMOUNT (merged-amount models) is deleted downstream
+    /// after amount_classifier / the LLM validator replace it with a
+    /// specific financial label; dropping it here instead strips every
+    /// currency anchor at ingest (#1466).
+    private static let reclassifiedLabels: Set<String> = ["AMOUNT"]
+
+    /// Canonical-name aliases, mirroring NON_CORE_LABEL_ALIASES in
+    /// receipt_dynamo.constants.
+    private static let labelAliases: [String: String] = [
+        "ADDRESS": "ADDRESS_LINE"
+    ]
+
     public let imageId: String
     public let receiptId: Int
     public let lineId: Int
@@ -198,11 +211,25 @@ public struct ReceiptWordLabel: Equatable {
                 let rawLabel = linePred.labels[wordIndex]
                 let confidence = linePred.confidences[wordIndex]
 
-                // Strip B-/I- prefix and keep only canonical CORE_LABELS.
-                let strippedLabel = stripBIOPrefix(rawLabel).uppercased()
+                // Strip B-/I- prefix and keep only canonical CORE_LABELS,
+                // plus the labels the cloud pipeline resolves itself:
+                // merged-amount models (layoutlm-v31+) emit AMOUNT for every
+                // currency word and ADDRESS instead of ADDRESS_LINE. AMOUNT
+                // must survive to DynamoDB — amount_classifier and the grok
+                // validator reclassify it into LINE_TOTAL/SUBTOTAL/TAX/
+                // GRAND_TOTAL, and those anchors gate all line-item labeling
+                // downstream (#1466). ADDRESS maps to its canonical alias,
+                // mirroring NON_CORE_LABEL_ALIASES in receipt_dynamo.
+                var strippedLabel = stripBIOPrefix(rawLabel).uppercased()
+                if let alias = labelAliases[strippedLabel] {
+                    strippedLabel = alias
+                }
 
                 // Skip "O" labels (Other/None) - they don't provide meaningful labeling
-                if strippedLabel == "O" || !coreLabels.contains(strippedLabel) {
+                if strippedLabel == "O"
+                    || !(coreLabels.contains(strippedLabel)
+                        || reclassifiedLabels.contains(strippedLabel))
+                {
                     continue
                 }
 

--- a/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptWordLabelTests.swift
+++ b/receipt_ocr_swift/Tests/ReceiptOCRCoreTests/ReceiptWordLabelTests.swift
@@ -2,17 +2,23 @@ import XCTest
 @testable import ReceiptOCRCore
 
 final class ReceiptWordLabelTests: XCTestCase {
-    func test_fromLinePredictions_filtersNonCoreMergePresetLabels() {
+    func test_fromLinePredictions_filtersUnknownButKeepsAmountAndAliases() {
+        // Merged-amount models (layoutlm-v31+) emit AMOUNT for currency
+        // words and ADDRESS instead of ADDRESS_LINE. Both must survive to
+        // DynamoDB — the cloud pipeline reclassifies AMOUNT into specific
+        // financial labels, and dropping it strips every currency anchor
+        // at ingest (#1466). Truly unknown labels are still filtered.
         let predictions = [
             LinePrediction(
-                tokens: ["store", "123", "visa", "tip"],
+                tokens: ["store", "4.99", "1234", "tip", "main"],
                 labels: [
                     "B-MERCHANT_NAME",
                     "B-AMOUNT",
                     "B-CARD_NUMBER",
                     "B-TIP",
+                    "B-ADDRESS",
                 ],
-                confidences: [0.95, 0.91, 0.88, 0.93],
+                confidences: [0.95, 0.91, 0.88, 0.93, 0.9],
                 allProbabilities: nil
             )
         ]
@@ -23,7 +29,10 @@ final class ReceiptWordLabelTests: XCTestCase {
             receiptId: 1
         )
 
-        XCTAssertEqual(labels.map(\.label), ["MERCHANT_NAME", "TIP"])
-        XCTAssertEqual(labels.map(\.wordId), [1, 4])
+        XCTAssertEqual(
+            labels.map(\.label),
+            ["MERCHANT_NAME", "AMOUNT", "TIP", "ADDRESS_LINE"]
+        )
+        XCTAssertEqual(labels.map(\.wordId), [1, 2, 4, 5])
     }
 }


### PR DESCRIPTION
Closes #1466.

## Root causes (two, independent)

**1. Chroma Cloud 20-query-embedding quota (the reported one).**
`section_verifier.verify_receipt_sections` batched one embedding per receipt row (25–55 in practice) into a single `query()`; Chroma Cloud rejects >20 with `Quota exceeded: 'Number of query embeddings'`. Every receipt with >20 rows lost Section KNN verification since ~Aug 14. Fixed centrally in `ChromaClient.query`: batches are chunked to ≤20 embeddings per request and the per-query result lists concatenated in order, so no call site can reintroduce the bug.

**2. Swift worker silently dropping AMOUNT (the actual label killer).**
The missing PRODUCT_NAME/LINE_TOTAL/GRAND_TOTAL/SUBTOTAL/TAX labels were **not** caused by the quota. The active model `layoutlm-v31-nonproduct-clean-20260729` emits `{ADDRESS, AMOUNT, DATE, MERCHANT_NAME, PAYMENT_METHOD, STORE_HOURS, TIME, WEBSITE}` — and `ReceiptWordLabel.fromLinePredictions` filtered out `AMOUNT` and `ADDRESS` because they aren't in `coreLabels`. The intersection is exactly the six header labels observed on every receipt since Aug 14. With no AMOUNT anchors in DynamoDB, `propose_line_item_labels` returns `[]` (`if not totals: return []`), the semantic proposer has no band, and grok gets nothing to reclassify. Evidence: the Aug-20 words deltas show money words `label_status=unvalidated` (no auto-inference label), while Aug-13 deltas show them labeled — the Aug-13 Mac was still running an older cached model with the full label set (its receipts also carry PHONE_NUMBER, which v31 doesn't have). Fixed by passing `AMOUNT` through (the cloud pipeline deletes/reclassifies it via `amount_classifier` + grok) and aliasing `ADDRESS`→`ADDRESS_LINE`, mirroring `NON_CORE_LABEL_ALIASES`.

Note: the issue's claim that the grok pass never ran was incorrect — CloudWatch shows `Async LLM validation complete: validated=N` for all 16 Aug-20 receipts; grok validated exactly the header labels because that's all that was ever proposed.

## Alerting
The swallowed verification failure now emits `UploadLambdaSectionVerificationError` (EMF, `EmbeddingWorkflow` namespace) with a CloudWatch alarm → critical-error SNS topic.

## Tests
- `test_query_chunks_large_embedding_batches` / `test_query_small_batch_single_request` (chunking + merge order, mock collection asserting ≤20 per call)
- `test_fromLinePredictions_filtersUnknownButKeepsAmountAndAliases` (replaces the test that asserted AMOUNT is dropped)
- `test_section_observability_emits_verification_error_metric`

## Deploy / follow-up
- Dev deploy + re-drive verification in progress (Swift binary must also be rebuilt on both Macs — the fix is in the worker, not just the Lambda).
- Prod gets the Lambda fix via CI on merge; prod ingests since ~Aug 14 need the same label check/backfill.
- The 16 dev receipts from the Aug-20 batch still need label backfill (without clobbering the manual `mcp-claude-review` corrections listed in #1466).

🤖 Generated with [Claude Code](https://claude.com/claude-code)