### PR TITLE
chore(security): patch glyph-studio transitive deps + swift-nio-http2

### DIFF
--- a/receipt_ocr_swift/Package.resolved
+++ b/receipt_ocr_swift/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "5d94b3ababfc2f6c5dfb1c5a14912e9fc46661e1b409ba767f7c322730d465fc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -167,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {
@@ -217,5 +218,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/tools/glyph-studio/package-lock.json
+++ b/tools/glyph-studio/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -788,9 +788,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -925,9 +925,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -976,9 +976,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
Clears 10 open dependabot security alerts across two dependency trees:

**tools/glyph-studio** (alerts 177/187 fast-uri, 191/192/193 ip-address, 195/196/198/199 hono, 206 @hono/node-server): all four packages are transitive via `@modelcontextprotocol/sdk` and every patched version fits the existing semver ranges, so this is a lockfile-only `npm audit fix` (no `--force`, 12 lines). Verified: import smoke of all four packages, `node --check` on the server scripts, and a live stdio MCP `initialize` handshake. Real exposure was low regardless — glyph-studio is a localhost/stdio dev tool.

**receipt_ocr_swift** (alert 162, GHSA-4px2-pw77-vc85 / CVE-2026-28898): swift-nio-http2 1.38.0 → 1.45.0 in `Package.resolved` only (transitive via soto → async-http-client). The CVE is request smuggling in the *server-side* HTTP/2→HTTP/1.1 codec; the OCR worker is a pure AWS client with no listening sockets, so this is hygiene. `swift build` completes cleanly; no decoder code touched, so Swift parity fixtures are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)