### PR TITLE
perf: reduce API Lambda cold starts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -383,8 +383,10 @@ jobs:
             scripts/test_capture_dev_api_profiles.py
 
       - name: Deploy dev stack
+        id: profiled-dev-deploy
         working-directory: infra
         env:
+          ENABLE_DEV_LAMBDA_PROFILING: "1"
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
           pulumi stack select tnorlund/portfolio/dev
@@ -409,6 +411,15 @@ jobs:
                 "api-profile-artifacts/${route}.importtime"
             fi
           done
+
+      - name: Disable dev profiling
+        if: always() && steps.profiled-dev-deploy.outcome == 'success'
+        working-directory: infra
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          pulumi stack select tnorlund/portfolio/dev
+          pulumi up --yes
 
       - name: Upload dev API profiles
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      profile_dev_api:
+        description: "Deploy and capture dev /images + /receipts profiles"
+        required: false
+        type: boolean
+        default: false
 
 # Superseded PR runs are cancelled (a new push makes the old one moot), but
 # main-push runs are NEVER cancelled: their `deploy` job runs `pulumi up`, and
@@ -329,6 +335,102 @@ jobs:
         with:
           name: playwright-report
           path: portfolio/playwright-report/
+          retention-days: 7
+
+  # ============================================================================
+  # MANUAL: targeted dev API profiling (never runs on push or pull_request)
+  # ============================================================================
+
+  profile-dev-api:
+    name: Profile dev API Lambdas
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.profile_dev_api
+    needs:
+      - lambda-syntax
+      - repository-tests
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-development
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Install infrastructure and profiling tools
+        run: |
+          pip install -e infra
+          pip install boto3 flameprof pytest tuna
+
+      - name: Test profiling instrumentation
+        run: |
+          python -m pytest -q \
+            infra/components/test_lambda_profiler.py \
+            infra/components/test_route_lambda.py \
+            scripts/test_capture_dev_api_profiles.py
+
+      - name: Deploy only the profiled dev functions
+        working-directory: infra
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          pulumi stack select tnorlund/portfolio/dev
+          mapfile -t TARGET_URNS < <(
+            pulumi stack export \
+              | jq -r '.deployment.resources[]
+                | select(.type == "aws:lambda/function:Function")
+                | select(
+                    (.urn | endswith("::api_images_GET_lambda")) or
+                    (.urn | endswith("::api_receipts_GET_lambda"))
+                  )
+                | .urn'
+          )
+          if [ "${#TARGET_URNS[@]}" -ne 2 ]; then
+            echo "Expected two target Lambda URNs, found ${#TARGET_URNS[@]}"
+            printf '%s\n' "${TARGET_URNS[@]}"
+            exit 1
+          fi
+          TARGET_ARGS=()
+          for urn in "${TARGET_URNS[@]}"; do
+            TARGET_ARGS+=(--target "$urn")
+          done
+          pulumi up --yes "${TARGET_ARGS[@]}"
+
+      - name: Capture handler and import profiles
+        run: |
+          mkdir -p api-profile-artifacts
+          python scripts/capture_dev_api_profiles.py \
+            --route images \
+            --route receipts \
+            --output-dir api-profile-artifacts \
+            | tee api-profile-artifacts/summary.json
+
+          for route in images receipts; do
+            flameprof \
+              --out "api-profile-artifacts/${route}-handler.svg" \
+              "api-profile-artifacts/${route}.prof"
+            if [ -s "api-profile-artifacts/${route}.importtime" ]; then
+              tuna \
+                --outdir "api-profile-artifacts/${route}-imports" \
+                "api-profile-artifacts/${route}.importtime"
+            fi
+          done
+
+      - name: Upload dev API profiles
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-api-lambda-profiles-${{ github.sha }}
+          path: api-profile-artifacts/
           retention-days: 7
 
   # ============================================================================

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -377,6 +377,8 @@ jobs:
           python -m pytest -q \
             infra/components/test_lambda_profiler.py \
             infra/components/test_route_lambda.py \
+            infra/routes/images/handler/test_handler.py \
+            infra/routes/receipts/handler/test_handler.py \
             scripts/test_capture_dev_api_profiles.py
 
       - name: Deploy dev stack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -379,32 +379,13 @@ jobs:
             infra/components/test_route_lambda.py \
             scripts/test_capture_dev_api_profiles.py
 
-      - name: Deploy only the profiled dev functions
+      - name: Deploy dev stack
         working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
           pulumi stack select tnorlund/portfolio/dev
-          mapfile -t TARGET_URNS < <(
-            pulumi stack export \
-              | jq -r '.deployment.resources[]
-                | select(.type == "aws:lambda/function:Function")
-                | select(
-                    (.urn | endswith("::api_images_GET_lambda")) or
-                    (.urn | endswith("::api_receipts_GET_lambda"))
-                  )
-                | .urn'
-          )
-          if [ "${#TARGET_URNS[@]}" -ne 2 ]; then
-            echo "Expected two target Lambda URNs, found ${#TARGET_URNS[@]}"
-            printf '%s\n' "${TARGET_URNS[@]}"
-            exit 1
-          fi
-          TARGET_ARGS=()
-          for urn in "${TARGET_URNS[@]}"; do
-            TARGET_ARGS+=(--target "$urn")
-          done
-          pulumi up --yes "${TARGET_ARGS[@]}"
+          pulumi up --yes
 
       - name: Capture handler and import profiles
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -375,6 +375,7 @@ jobs:
       - name: Test profiling instrumentation
         run: |
           python -m pytest -q \
+            infra/components/test_api_dynamo.py \
             infra/components/test_lambda_profiler.py \
             infra/components/test_route_lambda.py \
             infra/routes/images/handler/test_handler.py \

--- a/infra/components/api_dynamo.py
+++ b/infra/components/api_dynamo.py
@@ -1,0 +1,154 @@
+"""Small DynamoDB query client for latency-sensitive read-only API routes.
+
+This module intentionally avoids importing ``receipt_dynamo``. The general
+client composes every entity accessor and validates the table with
+``DescribeTable`` on construction; these routes need only two indexed queries
+and stable JSON conversion.
+"""
+
+import boto3
+
+CDN_FIELDS = (
+    "sha256",
+    "cdn_s3_bucket",
+    "cdn_s3_key",
+    "cdn_webp_s3_key",
+    "cdn_avif_s3_key",
+    "cdn_thumbnail_s3_key",
+    "cdn_thumbnail_webp_s3_key",
+    "cdn_thumbnail_avif_s3_key",
+    "cdn_small_s3_key",
+    "cdn_small_webp_s3_key",
+    "cdn_small_avif_s3_key",
+    "cdn_medium_s3_key",
+    "cdn_medium_webp_s3_key",
+    "cdn_medium_avif_s3_key",
+)
+
+_clients = {}
+
+
+def _string(item, field, default=None):
+    return item.get(field, {}).get("S", default)
+
+
+def _integer(item, field):
+    value = item.get(field, {}).get("N")
+    return int(value) if value is not None else None
+
+
+def _point(item, field):
+    return {key: float(value["N"]) for key, value in item[field]["M"].items()}
+
+
+def _cdn_fields(item):
+    return {field: _string(item, field) for field in CDN_FIELDS}
+
+
+def image_to_api(item):
+    """Convert one raw DynamoDB image item to the public API shape."""
+    return {
+        **_cdn_fields(item),
+        "image_id": item["PK"]["S"].split("#", 1)[1],
+        "width": _integer(item, "width"),
+        "height": _integer(item, "height"),
+        "timestamp_added": _string(item, "timestamp_added"),
+        "raw_s3_bucket": _string(item, "raw_s3_bucket"),
+        "raw_s3_key": _string(item, "raw_s3_key"),
+        "image_type": _string(item, "image_type", "SCAN"),
+        "receipt_count": _integer(item, "receipt_count"),
+    }
+
+
+def receipt_to_api(item):
+    """Convert one raw DynamoDB receipt item to the public API shape."""
+    return {
+        **_cdn_fields(item),
+        "image_id": item["PK"]["S"].split("#", 1)[1],
+        "receipt_id": int(item["SK"]["S"].split("#", 1)[1]),
+        "width": _integer(item, "width"),
+        "height": _integer(item, "height"),
+        "timestamp_added": _string(item, "timestamp_added"),
+        "raw_s3_bucket": _string(item, "raw_s3_bucket"),
+        "raw_s3_key": _string(item, "raw_s3_key"),
+        "top_left": _point(item, "top_left"),
+        "top_right": _point(item, "top_right"),
+        "bottom_left": _point(item, "bottom_left"),
+        "bottom_right": _point(item, "bottom_right"),
+    }
+
+
+class ApiDynamoClient:
+    """Read-only client exposing only the API routes' indexed queries."""
+
+    def __init__(self, table_name, dynamodb_client=None):
+        self.table_name = table_name
+        self._client = dynamodb_client or boto3.client(
+            "dynamodb", region_name="us-east-1"
+        )
+
+    def _query(self, parameters, converter, limit, last_evaluated_key):
+        results = []
+        current_key = last_evaluated_key
+        while True:
+            request = {
+                "TableName": self.table_name,
+                **parameters,
+            }
+            if current_key:
+                request["ExclusiveStartKey"] = current_key
+            if limit is not None:
+                request["Limit"] = limit - len(results)
+
+            response = self._client.query(**request)
+            results.extend(
+                converter(item) for item in response.get("Items", [])
+            )
+            next_key = response.get("LastEvaluatedKey")
+            if limit is not None and len(results) >= limit:
+                return results[:limit], next_key
+            if not next_key:
+                return results, None
+            current_key = next_key
+
+    def list_images_by_type(
+        self, image_type, limit=None, last_evaluated_key=None
+    ):
+        if image_type not in {"PHOTO", "SCAN"}:
+            raise ValueError("image_type must be PHOTO or SCAN")
+        return self._query(
+            {
+                "IndexName": "GSI3",
+                "KeyConditionExpression": "#type = :type",
+                "ExpressionAttributeNames": {"#type": "GSI3PK"},
+                "ExpressionAttributeValues": {
+                    ":type": {"S": f"IMAGE#{image_type}"}
+                },
+                "ScanIndexForward": False,
+            },
+            image_to_api,
+            limit,
+            last_evaluated_key,
+        )
+
+    def list_receipts(self, limit=None, last_evaluated_key=None):
+        return self._query(
+            {
+                "IndexName": "GSITYPE",
+                "KeyConditionExpression": "#type = :type",
+                "ExpressionAttributeNames": {"#type": "TYPE"},
+                "ExpressionAttributeValues": {":type": {"S": "RECEIPT"}},
+            },
+            receipt_to_api,
+            limit,
+            last_evaluated_key,
+        )
+
+
+def get_api_dynamo_client(table_name):
+    """Return one reusable client per table in the Lambda environment."""
+    client = _clients.get(table_name)
+    if client is None:
+        client = ApiDynamoClient(table_name)
+        _clients[table_name] = client
+    return client

--- a/infra/components/api_dynamo.py
+++ b/infra/components/api_dynamo.py
@@ -6,7 +6,7 @@ client composes every entity accessor and validates the table with
 and stable JSON conversion.
 """
 
-import boto3
+from botocore.session import Session
 
 CDN_FIELDS = (
     "sha256",
@@ -83,7 +83,7 @@ class ApiDynamoClient:
 
     def __init__(self, table_name, dynamodb_client=None):
         self.table_name = table_name
-        self._client = dynamodb_client or boto3.client(
+        self._client = dynamodb_client or Session().create_client(
             "dynamodb", region_name="us-east-1"
         )
 

--- a/infra/components/lambda_profiler.py
+++ b/infra/components/lambda_profiler.py
@@ -1,0 +1,95 @@
+"""Dev-only, request-gated cProfile capture for zip Lambda handlers.
+
+The helper has a deliberately tiny import surface. Profiling dependencies are
+loaded only after a request opts in with ``__profile=1``. The compressed
+``pstats`` payload is emitted in bounded CloudWatch log chunks so the normal
+handler package needs no profiler dependency or writable storage outside
+Lambda's ``/tmp`` directory.
+"""
+
+import os
+
+PROFILE_MARKER = "LAMBDA_PROFILE_CHUNK "
+PROFILE_QUERY_PARAM = "__profile"
+PROFILE_CHUNK_SIZE = 48_000
+
+_profile_captured = False
+
+
+def _requested(event):
+    if not isinstance(event, dict):
+        return False
+    params = event.get("queryStringParameters") or {}
+    return isinstance(params, dict) and params.get(PROFILE_QUERY_PARAM) == "1"
+
+
+def _emit_profile(profiler, context):
+    # Imports here do not pollute the Lambda INIT profile or the handler's
+    # cProfile sample.
+    import base64
+    import gzip
+    import json
+    import tempfile
+    import uuid
+
+    request_id = getattr(context, "aws_request_id", None)
+    profile_id = request_id or str(uuid.uuid4())
+    path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".prof", delete=False) as file:
+            path = file.name
+        profiler.dump_stats(path)
+        with open(path, "rb") as file:  # pylint: disable=unspecified-encoding
+            payload = base64.b64encode(gzip.compress(file.read())).decode(
+                "ascii"
+            )
+        total = max(
+            1,
+            (len(payload) + PROFILE_CHUNK_SIZE - 1) // PROFILE_CHUNK_SIZE,
+        )
+        for sequence in range(total):
+            start = sequence * PROFILE_CHUNK_SIZE
+            message = {
+                "event": "lambda_profile_chunk",
+                "profile_id": profile_id,
+                "sequence": sequence,
+                "total": total,
+                "encoding": "gzip+base64+pstats",
+                "data": payload[start : start + PROFILE_CHUNK_SIZE],
+            }
+            print(PROFILE_MARKER + json.dumps(message), flush=True)
+    finally:
+        if path is not None:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+def profile_handler(handler):
+    """Profile the first explicitly requested invocation in an environment."""
+    if os.environ.get("LAMBDA_PROFILE_ENABLED") != "1":
+        return handler
+
+    def wrapped(event, context):
+        global _profile_captured
+        if _profile_captured or not _requested(event):
+            return handler(event, context)
+
+        # Claim the one capture before running the handler so exceptions cannot
+        # repeatedly generate large profiles in the same execution environment.
+        _profile_captured = True
+        import cProfile
+
+        profiler = cProfile.Profile()
+        profiler.enable()
+        try:
+            return handler(event, context)
+        finally:
+            profiler.disable()
+            try:
+                _emit_profile(profiler, context)
+            except Exception as error:  # pragma: no cover - Lambda safeguard
+                print(f"LAMBDA_PROFILE_ERROR {error!r}", flush=True)
+
+    return wrapped

--- a/infra/components/route_lambda.py
+++ b/infra/components/route_lambda.py
@@ -6,6 +6,7 @@ route does not change its resource parent or URN.
 """
 
 import json
+import os
 from dataclasses import dataclass, field
 from typing import Mapping, Sequence
 
@@ -14,6 +15,9 @@ import pulumi_aws as aws
 
 BASIC_EXECUTION_POLICY_ARN = (
     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+)
+PROFILER_ASSET_PATH = os.path.join(
+    os.path.dirname(__file__), "lambda_profiler.py"
 )
 
 LAMBDA_ASSUME_ROLE_POLICY = json.dumps(
@@ -74,6 +78,7 @@ class RouteLambdaDefinition:
     handler: str = "index.handler"
     reserved_concurrent_executions: int | None = None
     function_options: pulumi.ResourceOptions | None = None
+    enable_dev_profiling: bool = False
 
     def __post_init__(self) -> None:
         for field_name in (
@@ -118,6 +123,7 @@ def create_route_lambda(
     definition: RouteLambdaDefinition,
 ) -> RouteLambdaResources:
     """Create the common resources for a file-archive API Lambda."""
+    stack = pulumi.get_stack()
     role = aws.iam.Role(
         definition.role_name,
         assume_role_policy=LAMBDA_ASSUME_ROLE_POLICY,
@@ -150,27 +156,37 @@ def create_route_lambda(
         policy_arn=BASIC_EXECUTION_POLICY_ARN,
     )
 
+    code_assets: dict[str, pulumi.Asset | pulumi.Archive] = {
+        ".": pulumi.FileArchive(definition.handler_directory)
+    }
+    environment = dict(definition.environment)
+    if definition.enable_dev_profiling:
+        code_assets["_lambda_profiler.py"] = pulumi.FileAsset(
+            PROFILER_ASSET_PATH
+        )
+        if stack == "dev":
+            environment.update(
+                {
+                    "LAMBDA_PROFILE_ENABLED": "1",
+                    "PYTHONPROFILEIMPORTTIME": "2",
+                }
+            )
+
     function = aws.lambda_.Function(
         definition.function_name,
         runtime=definition.runtime,
         architectures=[definition.architecture],
         role=role.arn,
-        code=pulumi.AssetArchive(
-            {".": pulumi.FileArchive(definition.handler_directory)}
-        ),
+        code=pulumi.AssetArchive(code_assets),
         handler=definition.handler,
         layers=list(definition.layers) if definition.layers else None,
-        environment=(
-            {"variables": dict(definition.environment)}
-            if definition.environment
-            else None
-        ),
+        environment={"variables": environment} if environment else None,
         memory_size=definition.memory_size,
         timeout=definition.timeout,
         reserved_concurrent_executions=(
             definition.reserved_concurrent_executions
         ),
-        tags={"environment": pulumi.get_stack()},
+        tags={"environment": stack},
         opts=definition.function_options,
     )
 

--- a/infra/components/route_lambda.py
+++ b/infra/components/route_lambda.py
@@ -19,6 +19,9 @@ BASIC_EXECUTION_POLICY_ARN = (
 PROFILER_ASSET_PATH = os.path.join(
     os.path.dirname(__file__), "lambda_profiler.py"
 )
+API_DYNAMO_ASSET_PATH = os.path.join(
+    os.path.dirname(__file__), "api_dynamo.py"
+)
 
 LAMBDA_ASSUME_ROLE_POLICY = json.dumps(
     {
@@ -79,6 +82,7 @@ class RouteLambdaDefinition:
     reserved_concurrent_executions: int | None = None
     function_options: pulumi.ResourceOptions | None = None
     enable_dev_profiling: bool = False
+    extra_code_assets: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         for field_name in (
@@ -159,6 +163,12 @@ def create_route_lambda(
     code_assets: dict[str, pulumi.Asset | pulumi.Archive] = {
         ".": pulumi.FileArchive(definition.handler_directory)
     }
+    code_assets.update(
+        {
+            archive_path: pulumi.FileAsset(source_path)
+            for archive_path, source_path in definition.extra_code_assets.items()
+        }
+    )
     environment = dict(definition.environment)
     if definition.enable_dev_profiling:
         code_assets["_lambda_profiler.py"] = pulumi.FileAsset(

--- a/infra/components/route_lambda.py
+++ b/infra/components/route_lambda.py
@@ -174,7 +174,10 @@ def create_route_lambda(
         code_assets["_lambda_profiler.py"] = pulumi.FileAsset(
             PROFILER_ASSET_PATH
         )
-        if stack == "dev":
+        if (
+            stack == "dev"
+            and os.environ.get("ENABLE_DEV_LAMBDA_PROFILING") == "1"
+        ):
             environment.update(
                 {
                     "LAMBDA_PROFILE_ENABLED": "1",

--- a/infra/components/test_api_dynamo.py
+++ b/infra/components/test_api_dynamo.py
@@ -1,0 +1,109 @@
+"""Tests for the latency-sensitive API DynamoDB query client."""
+
+from infra.components import api_dynamo
+
+
+def _value_map(x, y):
+    return {"M": {"x": {"N": str(x)}, "y": {"N": str(y)}}}
+
+
+def _image_item():
+    return {
+        "PK": {"S": "IMAGE#image-id"},
+        "SK": {"S": "IMAGE"},
+        "GSI3PK": {"S": "IMAGE#PHOTO"},
+        "GSI3SK": {"S": "NUM_RECEIPTS#00002"},
+        "width": {"N": "960"},
+        "height": {"N": "1280"},
+        "timestamp_added": {"S": "2026-08-20T00:00:00+00:00"},
+        "raw_s3_bucket": {"S": "raw-bucket"},
+        "raw_s3_key": {"S": "raw-key"},
+        "image_type": {"S": "PHOTO"},
+        "receipt_count": {"N": "2"},
+        "cdn_s3_bucket": {"S": "cdn-bucket"},
+    }
+
+
+def _receipt_item():
+    return {
+        "PK": {"S": "IMAGE#image-id"},
+        "SK": {"S": "RECEIPT#00003"},
+        "TYPE": {"S": "RECEIPT"},
+        "width": {"N": "320"},
+        "height": {"N": "640"},
+        "timestamp_added": {"S": "2026-08-20T00:00:00+00:00"},
+        "raw_s3_bucket": {"S": "raw-bucket"},
+        "raw_s3_key": {"S": "receipt-key"},
+        "top_left": _value_map(0.1, 0.2),
+        "top_right": _value_map(0.8, 0.2),
+        "bottom_left": _value_map(0.1, 0.9),
+        "bottom_right": _value_map(0.8, 0.9),
+    }
+
+
+class FakeDynamoDB:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def query(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+def test_lists_and_converts_one_image_with_precise_limit() -> None:
+    next_key = {"PK": {"S": "next"}}
+    dynamodb = FakeDynamoDB(
+        [{"Items": [_image_item()], "LastEvaluatedKey": next_key}]
+    )
+    client = api_dynamo.ApiDynamoClient("table", dynamodb)
+
+    images, returned_key = client.list_images_by_type("PHOTO", limit=1)
+
+    assert returned_key == next_key
+    assert images[0] == {
+        **{field: None for field in api_dynamo.CDN_FIELDS},
+        "cdn_s3_bucket": "cdn-bucket",
+        "image_id": "image-id",
+        "width": 960,
+        "height": 1280,
+        "timestamp_added": "2026-08-20T00:00:00+00:00",
+        "raw_s3_bucket": "raw-bucket",
+        "raw_s3_key": "raw-key",
+        "image_type": "PHOTO",
+        "receipt_count": 2,
+    }
+    assert dynamodb.calls[0]["Limit"] == 1
+    assert dynamodb.calls[0]["IndexName"] == "GSI3"
+
+
+def test_lists_and_converts_receipts() -> None:
+    dynamodb = FakeDynamoDB([{"Items": [_receipt_item()]}])
+    client = api_dynamo.ApiDynamoClient("table", dynamodb)
+
+    receipts, returned_key = client.list_receipts(limit=1)
+
+    assert returned_key is None
+    assert receipts[0]["image_id"] == "image-id"
+    assert receipts[0]["receipt_id"] == 3
+    assert receipts[0]["top_left"] == {"x": 0.1, "y": 0.2}
+    assert receipts[0]["cdn_s3_key"] is None
+    assert dynamodb.calls[0]["IndexName"] == "GSITYPE"
+
+
+def test_reuses_one_client_per_table(monkeypatch) -> None:
+    created = []
+
+    class FakeApiClient:
+        def __init__(self, table_name):
+            self.table_name = table_name
+            created.append(self)
+
+    monkeypatch.setattr(api_dynamo, "ApiDynamoClient", FakeApiClient)
+    monkeypatch.setattr(api_dynamo, "_clients", {})
+
+    first = api_dynamo.get_api_dynamo_client("table")
+    second = api_dynamo.get_api_dynamo_client("table")
+
+    assert first is second
+    assert len(created) == 1

--- a/infra/components/test_lambda_profiler.py
+++ b/infra/components/test_lambda_profiler.py
@@ -1,0 +1,81 @@
+"""Tests for request-gated Lambda cProfile capture."""
+
+import base64
+import gzip
+import json
+import pstats
+from types import SimpleNamespace
+
+import pytest
+
+from infra.components import lambda_profiler
+
+
+@pytest.fixture(autouse=True)
+def reset_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lambda_profiler, "_profile_captured", False)
+
+
+def test_disabled_profiler_returns_original_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LAMBDA_PROFILE_ENABLED", raising=False)
+
+    def handler(event, context):
+        return event, context
+
+    assert lambda_profiler.profile_handler(handler) is handler
+
+
+def test_profile_requires_opt_in_query(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("LAMBDA_PROFILE_ENABLED", "1")
+
+    def handler(event, _context):
+        return event["value"] + 1
+
+    wrapped = lambda_profiler.profile_handler(handler)
+
+    assert wrapped({"value": 2}, SimpleNamespace()) == 3
+    assert capsys.readouterr().out == ""
+
+
+def test_profile_chunks_reconstruct_valid_pstats(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("LAMBDA_PROFILE_ENABLED", "1")
+
+    def handler(event, _context):
+        return sum(range(event["count"]))
+
+    wrapped = lambda_profiler.profile_handler(handler)
+    event = {
+        "count": 100,
+        "queryStringParameters": {"__profile": "1"},
+    }
+    context = SimpleNamespace(aws_request_id="request-1474")
+
+    assert wrapped(event, context) == 4950
+
+    messages = []
+    for line in capsys.readouterr().out.splitlines():
+        assert line.startswith(lambda_profiler.PROFILE_MARKER)
+        messages.append(
+            json.loads(line[len(lambda_profiler.PROFILE_MARKER) :])
+        )
+    assert messages
+    assert {message["profile_id"] for message in messages} == {"request-1474"}
+    messages.sort(key=lambda message: message["sequence"])
+    encoded = "".join(message["data"] for message in messages)
+    profile_path = tmp_path / "handler.prof"
+    profile_path.write_bytes(gzip.decompress(base64.b64decode(encoded)))
+
+    stats = pstats.Stats(str(profile_path))
+    assert any(key[2] == "handler" for key in stats.stats)
+
+    # Only one capture is allowed per execution environment.
+    assert wrapped(event, context) == 4950
+    assert capsys.readouterr().out == ""

--- a/infra/components/test_route_lambda.py
+++ b/infra/components/test_route_lambda.py
@@ -179,6 +179,36 @@ def test_create_route_lambda_with_inline_policy_and_named_log_group(
     assert resources.policy_attachment is None
 
 
+def test_create_route_lambda_enables_dev_profiling(
+    mocked_resources: CreatedResources,
+) -> None:
+    definition = route_lambda.RouteLambdaDefinition(
+        role_name="api_images_lambda_role",
+        basic_execution_attachment_name="api_images_basic_execution",
+        function_name="api_images_GET_lambda",
+        log_group_name="api_images_log_group",
+        handler_directory="/tmp/handler",
+        environment={"TABLE_NAME": "table-name"},
+        enable_dev_profiling=True,
+    )
+
+    route_lambda.create_route_lambda(definition)
+
+    function_args = mocked_resources["functions"][0][1]
+    assert function_args["environment"] == {
+        "variables": {
+            "TABLE_NAME": "table-name",
+            "LAMBDA_PROFILE_ENABLED": "1",
+            "PYTHONPROFILEIMPORTTIME": "2",
+        }
+    }
+    code_assets = function_args["code"].assets
+    assert set(code_assets) == {".", "_lambda_profiler.py"}
+    assert code_assets["_lambda_profiler.py"].path == (
+        route_lambda.PROFILER_ASSET_PATH
+    )
+
+
 @pytest.mark.parametrize(
     ("changes", "message"),
     [

--- a/infra/components/test_route_lambda.py
+++ b/infra/components/test_route_lambda.py
@@ -181,7 +181,9 @@ def test_create_route_lambda_with_inline_policy_and_named_log_group(
 
 def test_create_route_lambda_enables_dev_profiling(
     mocked_resources: CreatedResources,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("ENABLE_DEV_LAMBDA_PROFILING", "1")
     definition = route_lambda.RouteLambdaDefinition(
         role_name="api_images_lambda_role",
         basic_execution_attachment_name="api_images_basic_execution",
@@ -213,6 +215,30 @@ def test_create_route_lambda_enables_dev_profiling(
     assert code_assets["_lambda_profiler.py"].path == (
         route_lambda.PROFILER_ASSET_PATH
     )
+
+
+def test_dev_profiler_is_inert_without_deploy_opt_in(
+    mocked_resources: CreatedResources,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ENABLE_DEV_LAMBDA_PROFILING", raising=False)
+    definition = route_lambda.RouteLambdaDefinition(
+        role_name="role",
+        basic_execution_attachment_name="basic",
+        function_name="function",
+        log_group_name="logs",
+        handler_directory="/tmp/handler",
+        environment={"TABLE_NAME": "table-name"},
+        enable_dev_profiling=True,
+    )
+
+    route_lambda.create_route_lambda(definition)
+
+    function_args = mocked_resources["functions"][0][1]
+    assert function_args["environment"] == {
+        "variables": {"TABLE_NAME": "table-name"}
+    }
+    assert "_lambda_profiler.py" in function_args["code"].assets
 
 
 @pytest.mark.parametrize(

--- a/infra/components/test_route_lambda.py
+++ b/infra/components/test_route_lambda.py
@@ -190,6 +190,7 @@ def test_create_route_lambda_enables_dev_profiling(
         handler_directory="/tmp/handler",
         environment={"TABLE_NAME": "table-name"},
         enable_dev_profiling=True,
+        extra_code_assets={"_api_dynamo.py": "/tmp/api_dynamo.py"},
     )
 
     route_lambda.create_route_lambda(definition)
@@ -203,7 +204,12 @@ def test_create_route_lambda_enables_dev_profiling(
         }
     }
     code_assets = function_args["code"].assets
-    assert set(code_assets) == {".", "_lambda_profiler.py"}
+    assert set(code_assets) == {
+        ".",
+        "_api_dynamo.py",
+        "_lambda_profiler.py",
+    }
+    assert code_assets["_api_dynamo.py"].path == "/tmp/api_dynamo.py"
     assert code_assets["_lambda_profiler.py"].path == (
         route_lambda.PROFILER_ASSET_PATH
     )

--- a/infra/routes/images/handler/index.py
+++ b/infra/routes/images/handler/index.py
@@ -3,6 +3,7 @@ import logging
 import os
 import random
 
+from _lambda_profiler import profile_handler
 from receipt_dynamo import DynamoClient
 from receipt_dynamo.constants import ImageType
 
@@ -12,6 +13,7 @@ logger.setLevel(logging.INFO)
 DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
 
 
+@profile_handler
 def handler(event, _):
     logger.info("Received event: %s", event)
     http_method = event["requestContext"]["http"]["method"].upper()

--- a/infra/routes/images/handler/index.py
+++ b/infra/routes/images/handler/index.py
@@ -11,6 +11,14 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
+_dynamo_client = None
+
+
+def _get_dynamo_client():
+    global _dynamo_client
+    if _dynamo_client is None:
+        _dynamo_client = DynamoClient(DYNAMODB_TABLE_NAME)
+    return _dynamo_client
 
 
 @profile_handler
@@ -19,7 +27,6 @@ def handler(event, _):
     http_method = event["requestContext"]["http"]["method"].upper()
 
     if http_method == "GET":
-        client = DynamoClient(DYNAMODB_TABLE_NAME)
         query_params = event.get("queryStringParameters") or {}
 
         # Check for optional 'image_type' parameter
@@ -28,6 +35,11 @@ def handler(event, _):
         # Check for an optional 'limit'
         limit_param = query_params.get("limit")
         limit = int(limit_param) if limit_param is not None else None
+        if limit is not None and limit <= 0:
+            return {
+                "statusCode": 400,
+                "body": "limit must be a positive integer",
+            }
 
         # Check for an optional 'lastEvaluatedKey'
         last_evaluated_key = None
@@ -40,6 +52,7 @@ def handler(event, _):
                 logger.error("Error decoding lastEvaluatedKey; ignoring it.")
                 last_evaluated_key = None
 
+        client = _get_dynamo_client()
         if image_type:
             # If image_type is specified, use listImagesByType
             raw_images, lek = client.list_images_by_type(
@@ -61,35 +74,41 @@ def handler(event, _):
 
             # If limit is specified, split it between Photo and Scan
             if limit:
-                photo_limit = limit // 2
-                scan_limit = limit - photo_limit
+                photo_limit = (limit + 1) // 2
+                scan_limit = limit // 2
             else:
                 photo_limit = None
                 scan_limit = None
 
             # Fetch Photo images
-            photo_images, photo_lek = client.list_images_by_type(
-                image_type=ImageType.PHOTO.value,
-                limit=photo_limit,
-                last_evaluated_key=(
-                    last_evaluated_key.get("photo")
-                    if last_evaluated_key
-                    and isinstance(last_evaluated_key, dict)
-                    else None
-                ),
-            )
+            if photo_limit != 0:
+                photo_images, photo_lek = client.list_images_by_type(
+                    image_type=ImageType.PHOTO.value,
+                    limit=photo_limit,
+                    last_evaluated_key=(
+                        last_evaluated_key.get("photo")
+                        if last_evaluated_key
+                        and isinstance(last_evaluated_key, dict)
+                        else None
+                    ),
+                )
+            else:
+                photo_images, photo_lek = [], None
 
             # Fetch Scan images
-            scan_images, scan_lek = client.list_images_by_type(
-                image_type=ImageType.SCAN.value,
-                limit=scan_limit,
-                last_evaluated_key=(
-                    last_evaluated_key.get("scan")
-                    if last_evaluated_key
-                    and isinstance(last_evaluated_key, dict)
-                    else None
-                ),
-            )
+            if scan_limit != 0:
+                scan_images, scan_lek = client.list_images_by_type(
+                    image_type=ImageType.SCAN.value,
+                    limit=scan_limit,
+                    last_evaluated_key=(
+                        last_evaluated_key.get("scan")
+                        if last_evaluated_key
+                        and isinstance(last_evaluated_key, dict)
+                        else None
+                    ),
+                )
+            else:
+                scan_images, scan_lek = [], None
 
             # Combine images and remove duplicates
             # Use a set to track unique image_ids

--- a/infra/routes/images/handler/index.py
+++ b/infra/routes/images/handler/index.py
@@ -3,22 +3,13 @@ import logging
 import os
 import random
 
+from _api_dynamo import get_api_dynamo_client
 from _lambda_profiler import profile_handler
-from receipt_dynamo import DynamoClient
-from receipt_dynamo.constants import ImageType
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
-_dynamo_client = None
-
-
-def _get_dynamo_client():
-    global _dynamo_client
-    if _dynamo_client is None:
-        _dynamo_client = DynamoClient(DYNAMODB_TABLE_NAME)
-    return _dynamo_client
 
 
 @profile_handler
@@ -52,7 +43,7 @@ def handler(event, _):
                 logger.error("Error decoding lastEvaluatedKey; ignoring it.")
                 last_evaluated_key = None
 
-        client = _get_dynamo_client()
+        client = get_api_dynamo_client(DYNAMODB_TABLE_NAME)
         if image_type:
             # If image_type is specified, use listImagesByType
             raw_images, lek = client.list_images_by_type(
@@ -64,8 +55,8 @@ def handler(event, _):
             seen_ids = set()
             images = []
             for img in raw_images:
-                if img.image_id not in seen_ids:
-                    seen_ids.add(img.image_id)
+                if img["image_id"] not in seen_ids:
+                    seen_ids.add(img["image_id"])
                     images.append(img)
         else:
             # If no image_type, fetch equal distribution of Photo and Scan
@@ -83,7 +74,7 @@ def handler(event, _):
             # Fetch Photo images
             if photo_limit != 0:
                 photo_images, photo_lek = client.list_images_by_type(
-                    image_type=ImageType.PHOTO.value,
+                    image_type="PHOTO",
                     limit=photo_limit,
                     last_evaluated_key=(
                         last_evaluated_key.get("photo")
@@ -98,7 +89,7 @@ def handler(event, _):
             # Fetch Scan images
             if scan_limit != 0:
                 scan_images, scan_lek = client.list_images_by_type(
-                    image_type=ImageType.SCAN.value,
+                    image_type="SCAN",
                     limit=scan_limit,
                     last_evaluated_key=(
                         last_evaluated_key.get("scan")
@@ -116,8 +107,8 @@ def handler(event, _):
             unique_images = []
 
             for img in photo_images + scan_images:
-                if img.image_id not in seen_ids:
-                    seen_ids.add(img.image_id)
+                if img["image_id"] not in seen_ids:
+                    seen_ids.add(img["image_id"])
                     unique_images.append(img)
 
             # Shuffle for mixed distribution

--- a/infra/routes/images/handler/test_handler.py
+++ b/infra/routes/images/handler/test_handler.py
@@ -1,0 +1,85 @@
+"""Tests for the images API handler's bounded queries and client reuse."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+class FakeImage:
+    def __init__(self, image_id):
+        self.image_id = image_id
+
+    def __iter__(self):
+        yield "image_id", self.image_id
+
+
+class FakeDynamoClient:
+    instances = []
+
+    def __init__(self, table_name):
+        self.table_name = table_name
+        self.calls = []
+        self.instances.append(self)
+
+    def list_images_by_type(self, **kwargs):
+        self.calls.append(kwargs)
+        return ([FakeImage(kwargs["image_type"])], None)
+
+
+@pytest.fixture
+def handler_module(monkeypatch):
+    FakeDynamoClient.instances = []
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "dev-table")
+
+    profiler = ModuleType("_lambda_profiler")
+    profiler.profile_handler = lambda handler: handler
+    dynamo = ModuleType("receipt_dynamo")
+    dynamo.DynamoClient = FakeDynamoClient
+    constants = ModuleType("receipt_dynamo.constants")
+    constants.ImageType = SimpleNamespace(
+        PHOTO=SimpleNamespace(value="PHOTO"),
+        SCAN=SimpleNamespace(value="SCAN"),
+    )
+    monkeypatch.setitem(sys.modules, "_lambda_profiler", profiler)
+    monkeypatch.setitem(sys.modules, "receipt_dynamo", dynamo)
+    monkeypatch.setitem(sys.modules, "receipt_dynamo.constants", constants)
+
+    path = Path(__file__).with_name("index.py")
+    spec = importlib.util.spec_from_file_location("images_handler", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _event(limit):
+    return {
+        "requestContext": {"http": {"method": "GET"}},
+        "queryStringParameters": {"limit": str(limit)},
+    }
+
+
+def test_limit_one_runs_one_bounded_query(handler_module) -> None:
+    response = handler_module.handler(_event(1), None)
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"])["images"] == [{"image_id": "PHOTO"}]
+    assert FakeDynamoClient.instances[0].calls == [
+        {
+            "image_type": "PHOTO",
+            "limit": 1,
+            "last_evaluated_key": None,
+        }
+    ]
+
+
+def test_reuses_client_and_rejects_non_positive_limit(handler_module) -> None:
+    handler_module.handler(_event(2), None)
+    handler_module.handler(_event(2), None)
+
+    assert len(FakeDynamoClient.instances) == 1
+    assert handler_module.handler(_event(0), None)["statusCode"] == 400

--- a/infra/routes/images/handler/test_handler.py
+++ b/infra/routes/images/handler/test_handler.py
@@ -4,17 +4,9 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 
 import pytest
-
-
-class FakeImage:
-    def __init__(self, image_id):
-        self.image_id = image_id
-
-    def __iter__(self):
-        yield "image_id", self.image_id
 
 
 class FakeDynamoClient:
@@ -27,7 +19,7 @@ class FakeDynamoClient:
 
     def list_images_by_type(self, **kwargs):
         self.calls.append(kwargs)
-        return ([FakeImage(kwargs["image_type"])], None)
+        return ([{"image_id": kwargs["image_type"]}], None)
 
 
 @pytest.fixture
@@ -37,16 +29,17 @@ def handler_module(monkeypatch):
 
     profiler = ModuleType("_lambda_profiler")
     profiler.profile_handler = lambda handler: handler
-    dynamo = ModuleType("receipt_dynamo")
-    dynamo.DynamoClient = FakeDynamoClient
-    constants = ModuleType("receipt_dynamo.constants")
-    constants.ImageType = SimpleNamespace(
-        PHOTO=SimpleNamespace(value="PHOTO"),
-        SCAN=SimpleNamespace(value="SCAN"),
-    )
+    clients = {}
+    api_dynamo = ModuleType("_api_dynamo")
+
+    def get_api_dynamo_client(table_name):
+        if table_name not in clients:
+            clients[table_name] = FakeDynamoClient(table_name)
+        return clients[table_name]
+
+    api_dynamo.get_api_dynamo_client = get_api_dynamo_client
     monkeypatch.setitem(sys.modules, "_lambda_profiler", profiler)
-    monkeypatch.setitem(sys.modules, "receipt_dynamo", dynamo)
-    monkeypatch.setitem(sys.modules, "receipt_dynamo.constants", constants)
+    monkeypatch.setitem(sys.modules, "_api_dynamo", api_dynamo)
 
     path = Path(__file__).with_name("index.py")
     spec = importlib.util.spec_from_file_location("images_handler", path)

--- a/infra/routes/images/infra.py
+++ b/infra/routes/images/infra.py
@@ -50,6 +50,7 @@ resources = create_route_lambda(
         layers=(dynamo_layer.arn,),
         memory_size=1024,
         timeout=30,
+        enable_dev_profiling=True,
     )
 )
 

--- a/infra/routes/images/infra.py
+++ b/infra/routes/images/infra.py
@@ -4,8 +4,8 @@ import json
 import os
 
 from dynamo_db import dynamodb_table
-from infra.components.lambda_layer import dynamo_layer
 from infra.components.route_lambda import (
+    API_DYNAMO_ASSET_PATH,
     ManagedPolicyDefinition,
     RouteLambdaDefinition,
     create_route_lambda,
@@ -47,10 +47,10 @@ resources = create_route_lambda(
             ),
         ),
         environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
-        layers=(dynamo_layer.arn,),
         memory_size=1024,
         timeout=30,
         enable_dev_profiling=True,
+        extra_code_assets={"_api_dynamo.py": API_DYNAMO_ASSET_PATH},
     )
 )
 

--- a/infra/routes/receipts/handler/index.py
+++ b/infra/routes/receipts/handler/index.py
@@ -2,22 +2,14 @@ import json
 import logging
 import os
 
+from _api_dynamo import get_api_dynamo_client
 from _lambda_profiler import profile_handler
-from receipt_dynamo import DynamoClient  # type: ignore
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 # Get the environment variables
 dynamodb_table_name = os.environ["DYNAMODB_TABLE_NAME"]
-_dynamo_client = None
-
-
-def _get_dynamo_client():
-    global _dynamo_client
-    if _dynamo_client is None:
-        _dynamo_client = DynamoClient(dynamodb_table_name)
-    return _dynamo_client
 
 
 @profile_handler
@@ -47,7 +39,7 @@ def handler(event, _):
                 logger.error("Error decoding lastEvaluatedKey; ignoring it.")
                 lastEvaluatedKey = None
 
-        client = _get_dynamo_client()
+        client = get_api_dynamo_client(dynamodb_table_name)
         # Call listReceipts with the provided parameters.
         receipts, lek = client.list_receipts(
             limit=limit, last_evaluated_key=lastEvaluatedKey

--- a/infra/routes/receipts/handler/index.py
+++ b/infra/routes/receipts/handler/index.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 
+from _lambda_profiler import profile_handler
 from receipt_dynamo import DynamoClient  # type: ignore
 
 logger = logging.getLogger()
@@ -11,6 +12,7 @@ logger.setLevel(logging.INFO)
 dynamodb_table_name = os.environ["DYNAMODB_TABLE_NAME"]
 
 
+@profile_handler
 def handler(event, _):
     logger.info("Received event: %s", event)
     http_method = event["requestContext"]["http"]["method"].upper()

--- a/infra/routes/receipts/handler/index.py
+++ b/infra/routes/receipts/handler/index.py
@@ -10,6 +10,14 @@ logger.setLevel(logging.INFO)
 
 # Get the environment variables
 dynamodb_table_name = os.environ["DYNAMODB_TABLE_NAME"]
+_dynamo_client = None
+
+
+def _get_dynamo_client():
+    global _dynamo_client
+    if _dynamo_client is None:
+        _dynamo_client = DynamoClient(dynamodb_table_name)
+    return _dynamo_client
 
 
 @profile_handler
@@ -18,13 +26,17 @@ def handler(event, _):
     http_method = event["requestContext"]["http"]["method"].upper()
 
     if http_method == "GET":
-        client = DynamoClient(dynamodb_table_name)
         query_params = event.get("queryStringParameters") or {}
 
         # Check for an optional 'limit'
         limit = query_params.get("limit")
         if limit is not None:
             limit = int(limit)
+            if limit <= 0:
+                return {
+                    "statusCode": 400,
+                    "body": "limit must be a positive integer",
+                }
 
         # Check for an optional 'lastEvaluatedKey'
         lastEvaluatedKey = None
@@ -35,6 +47,7 @@ def handler(event, _):
                 logger.error("Error decoding lastEvaluatedKey; ignoring it.")
                 lastEvaluatedKey = None
 
+        client = _get_dynamo_client()
         # Call listReceipts with the provided parameters.
         receipts, lek = client.list_receipts(
             limit=limit, last_evaluated_key=lastEvaluatedKey

--- a/infra/routes/receipts/handler/test_handler.py
+++ b/infra/routes/receipts/handler/test_handler.py
@@ -28,10 +28,17 @@ def handler_module(monkeypatch):
 
     profiler = ModuleType("_lambda_profiler")
     profiler.profile_handler = lambda handler: handler
-    dynamo = ModuleType("receipt_dynamo")
-    dynamo.DynamoClient = FakeDynamoClient
+    clients = {}
+    api_dynamo = ModuleType("_api_dynamo")
+
+    def get_api_dynamo_client(table_name):
+        if table_name not in clients:
+            clients[table_name] = FakeDynamoClient(table_name)
+        return clients[table_name]
+
+    api_dynamo.get_api_dynamo_client = get_api_dynamo_client
     monkeypatch.setitem(sys.modules, "_lambda_profiler", profiler)
-    monkeypatch.setitem(sys.modules, "receipt_dynamo", dynamo)
+    monkeypatch.setitem(sys.modules, "_api_dynamo", api_dynamo)
 
     path = Path(__file__).with_name("index.py")
     spec = importlib.util.spec_from_file_location("receipts_handler", path)

--- a/infra/routes/receipts/handler/test_handler.py
+++ b/infra/routes/receipts/handler/test_handler.py
@@ -1,0 +1,64 @@
+"""Tests for the receipts API handler's client reuse and limit validation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+class FakeDynamoClient:
+    instances = []
+
+    def __init__(self, table_name):
+        self.table_name = table_name
+        self.calls = []
+        self.instances.append(self)
+
+    def list_receipts(self, **kwargs):
+        self.calls.append(kwargs)
+        return ([{"receipt_id": 1}], None)
+
+
+@pytest.fixture
+def handler_module(monkeypatch):
+    FakeDynamoClient.instances = []
+    monkeypatch.setenv("DYNAMODB_TABLE_NAME", "dev-table")
+
+    profiler = ModuleType("_lambda_profiler")
+    profiler.profile_handler = lambda handler: handler
+    dynamo = ModuleType("receipt_dynamo")
+    dynamo.DynamoClient = FakeDynamoClient
+    monkeypatch.setitem(sys.modules, "_lambda_profiler", profiler)
+    monkeypatch.setitem(sys.modules, "receipt_dynamo", dynamo)
+
+    path = Path(__file__).with_name("index.py")
+    spec = importlib.util.spec_from_file_location("receipts_handler", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _event(limit):
+    return {
+        "requestContext": {"http": {"method": "GET"}},
+        "queryStringParameters": {"limit": str(limit)},
+    }
+
+
+def test_reuses_client_across_invocations(handler_module) -> None:
+    handler_module.handler(_event(1), None)
+    handler_module.handler(_event(1), None)
+
+    assert len(FakeDynamoClient.instances) == 1
+    assert FakeDynamoClient.instances[0].calls == [
+        {"limit": 1, "last_evaluated_key": None},
+        {"limit": 1, "last_evaluated_key": None},
+    ]
+
+
+def test_rejects_non_positive_limit(handler_module) -> None:
+    assert handler_module.handler(_event(0), None)["statusCode"] == 400
+    assert FakeDynamoClient.instances == []

--- a/infra/routes/receipts/infra.py
+++ b/infra/routes/receipts/infra.py
@@ -55,6 +55,7 @@ resources = create_route_lambda(
         layers=(dynamo_layer.arn,),
         memory_size=1024,
         timeout=120,
+        enable_dev_profiling=True,
     )
 )
 

--- a/infra/routes/receipts/infra.py
+++ b/infra/routes/receipts/infra.py
@@ -4,8 +4,8 @@ import json
 import os
 
 from dynamo_db import dynamodb_table
-from infra.components.lambda_layer import dynamo_layer
 from infra.components.route_lambda import (
+    API_DYNAMO_ASSET_PATH,
     ManagedPolicyDefinition,
     RouteLambdaDefinition,
     create_route_lambda,
@@ -52,10 +52,10 @@ resources = create_route_lambda(
             ),
         ),
         environment={"DYNAMODB_TABLE_NAME": DYNAMODB_TABLE_NAME},
-        layers=(dynamo_layer.arn,),
         memory_size=1024,
         timeout=120,
         enable_dev_profiling=True,
+        extra_code_assets={"_api_dynamo.py": API_DYNAMO_ASSET_PATH},
     )
 )
 

--- a/scripts/capture_dev_api_profiles.py
+++ b/scripts/capture_dev_api_profiles.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Capture dev Lambda cProfile and import-time artifacts from CloudWatch.
+
+The target functions must have the request-gated profiler enabled by
+``RouteLambdaDefinition.enable_dev_profiling``. This script invokes each route
+with ``__profile=1``, reconstructs the compressed pstats chunks, and extracts
+the import-time trace from the same Lambda log stream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import json
+import math
+import re
+import time
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import boto3
+
+PROFILE_MARKER = "LAMBDA_PROFILE_CHUNK "
+REPORT_PATTERN = re.compile(
+    r"REPORT RequestId: (?P<request_id>\S+).*?"
+    r"Duration: (?P<duration>[\d.]+) ms.*?"
+    r"Memory Size: (?P<memory_size>\d+) MB.*?"
+    r"Max Memory Used: (?P<max_memory>\d+) MB"
+)
+INIT_DURATION_PATTERN = re.compile(r"Init Duration: (?P<value>[\d.]+) ms")
+
+
+@dataclass(frozen=True)
+class RouteSpec:
+    logical_name: str
+    path: str
+
+
+@dataclass(frozen=True)
+class InvocationTiming:
+    status: int
+    ttfb_ms: float
+    total_ms: float
+    response_bytes: int
+
+
+ROUTES = {
+    "images": RouteSpec(
+        logical_name="api_images_GET_lambda",
+        path="/images?limit=1",
+    ),
+    "receipts": RouteSpec(
+        logical_name="api_receipts_GET_lambda",
+        path="/receipts?limit=1",
+    ),
+}
+
+
+def discover_function(lambda_client, logical_name: str) -> str:
+    """Resolve a Pulumi auto-named function from its stable logical prefix."""
+    matches = []
+    paginator = lambda_client.get_paginator("list_functions")
+    for page in paginator.paginate():
+        for function in page.get("Functions", []):
+            name = function["FunctionName"]
+            if not (
+                name == logical_name or name.startswith(f"{logical_name}-")
+            ):
+                continue
+            tags = lambda_client.list_tags(
+                Resource=function["FunctionArn"]
+            ).get("Tags", {})
+            if tags.get("environment") == "dev":
+                matches.append(name)
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one function for {logical_name!r}, found {matches}"
+        )
+    return matches[0]
+
+
+def invoke_profile(base_url: str, path: str) -> InvocationTiming:
+    """Invoke a route and measure response-header TTFB and total time."""
+    separator = "&" if "?" in path else "?"
+    url = f"{base_url.rstrip('/')}{path}{separator}__profile=1"
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json"},
+        method="GET",
+    )
+    started = time.perf_counter()
+    with urllib.request.urlopen(request, timeout=120) as response:
+        headers_received = time.perf_counter()
+        payload = response.read()
+        completed = time.perf_counter()
+        status = response.status
+    return InvocationTiming(
+        status=status,
+        ttfb_ms=(headers_received - started) * 1000,
+        total_ms=(completed - started) * 1000,
+        response_bytes=len(payload),
+    )
+
+
+def _parse_chunk(message: str) -> dict[str, Any] | None:
+    marker_index = message.find(PROFILE_MARKER)
+    if marker_index < 0:
+        return None
+    payload = message[marker_index + len(PROFILE_MARKER) :].strip()
+    return json.loads(payload)
+
+
+def _complete_profiles(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for event in events:
+        chunk = _parse_chunk(event["message"])
+        if chunk is None:
+            continue
+        profile = grouped.setdefault(
+            chunk["profile_id"],
+            {
+                "chunks": {},
+                "total": chunk["total"],
+                "timestamp": event["timestamp"],
+                "log_stream": event["logStreamName"],
+            },
+        )
+        profile["chunks"][chunk["sequence"]] = chunk["data"]
+        profile["timestamp"] = max(profile["timestamp"], event["timestamp"])
+
+    complete = []
+    for profile_id, profile in grouped.items():
+        if len(profile["chunks"]) != profile["total"]:
+            continue
+        encoded = "".join(
+            profile["chunks"][index] for index in range(profile["total"])
+        )
+        complete.append(
+            {
+                "profile_id": profile_id,
+                "encoded": encoded,
+                "timestamp": profile["timestamp"],
+                "log_stream": profile["log_stream"],
+            }
+        )
+    return complete
+
+
+def wait_for_profile(
+    logs_client,
+    log_group: str,
+    started_ms: int,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Poll CloudWatch until a complete chunked profile is visible."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        events = []
+        kwargs = {
+            "logGroupName": log_group,
+            "startTime": started_ms,
+            "filterPattern": f'"{PROFILE_MARKER.strip()}"',
+        }
+        while True:
+            response = logs_client.filter_log_events(**kwargs)
+            events.extend(response.get("events", []))
+            token = response.get("nextToken")
+            if not token:
+                break
+            kwargs["nextToken"] = token
+        complete = _complete_profiles(events)
+        if complete:
+            return max(complete, key=lambda profile: profile["timestamp"])
+        time.sleep(2)
+    raise TimeoutError(f"profile not found in {log_group}")
+
+
+def read_log_stream(logs_client, log_group: str, log_stream: str) -> list[str]:
+    """Read one Lambda log stream from the beginning."""
+    messages = []
+    token = None
+    while True:
+        kwargs = {
+            "logGroupName": log_group,
+            "logStreamName": log_stream,
+            "startFromHead": True,
+        }
+        if token is not None:
+            kwargs["nextToken"] = token
+        response = logs_client.get_log_events(**kwargs)
+        messages.extend(
+            event["message"] for event in response.get("events", [])
+        )
+        next_token = response.get("nextForwardToken")
+        if next_token == token:
+            break
+        token = next_token
+    return messages
+
+
+def extract_import_trace(messages: list[str]) -> str:
+    lines = []
+    for message in messages:
+        for line in message.splitlines():
+            index = line.find("import time:")
+            if index >= 0:
+                lines.append(line[index:])
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def extract_report(messages: list[str], request_id: str) -> dict[str, Any]:
+    for message in reversed(messages):
+        match = REPORT_PATTERN.search(message)
+        if match and match.group("request_id") == request_id:
+            values = match.groupdict()
+            init_match = INIT_DURATION_PATTERN.search(message)
+            return {
+                "duration_ms": float(values["duration"]),
+                "memory_size_mb": int(values["memory_size"]),
+                "max_memory_mb": int(values["max_memory"]),
+                "init_duration_ms": (
+                    float(init_match.group("value"))
+                    if init_match is not None
+                    else None
+                ),
+            }
+    return {}
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def collect_baseline(
+    logs_client,
+    log_group: str,
+    days: int,
+) -> dict[str, Any]:
+    """Summarize recent Lambda REPORT lines for one function."""
+    started_ms = int((time.time() - days * 86_400) * 1000)
+    events = []
+    kwargs = {
+        "logGroupName": log_group,
+        "startTime": started_ms,
+        "filterPattern": '"REPORT RequestId"',
+    }
+    while True:
+        response = logs_client.filter_log_events(**kwargs)
+        events.extend(response.get("events", []))
+        token = response.get("nextToken")
+        if not token:
+            break
+        kwargs["nextToken"] = token
+
+    reports = []
+    for event in events:
+        match = REPORT_PATTERN.search(event["message"])
+        if match is None:
+            continue
+        values = match.groupdict()
+        init_match = INIT_DURATION_PATTERN.search(event["message"])
+        reports.append(
+            {
+                "duration_ms": float(values["duration"]),
+                "memory_size_mb": int(values["memory_size"]),
+                "max_memory_mb": int(values["max_memory"]),
+                "init_duration_ms": (
+                    float(init_match.group("value"))
+                    if init_match is not None
+                    else None
+                ),
+            }
+        )
+    durations = [report["duration_ms"] for report in reports]
+    init_durations = [
+        report["init_duration_ms"]
+        for report in reports
+        if report["init_duration_ms"] is not None
+    ]
+    max_memory = [report["max_memory_mb"] for report in reports]
+    return {
+        "days": days,
+        "invocations": len(reports),
+        "cold_starts": len(init_durations),
+        "cold_start_rate": (
+            len(init_durations) / len(reports) if reports else None
+        ),
+        "duration_p50_ms": _percentile(durations, 0.50),
+        "duration_p99_ms": _percentile(durations, 0.99),
+        "init_p50_ms": _percentile(init_durations, 0.50),
+        "init_p99_ms": _percentile(init_durations, 0.99),
+        "max_memory_p99_mb": _percentile(max_memory, 0.99),
+        "memory_size_mb": (reports[-1]["memory_size_mb"] if reports else None),
+    }
+
+
+def capture_route(
+    route: str,
+    spec: RouteSpec,
+    base_url: str,
+    output_dir: Path,
+    lambda_client,
+    logs_client,
+    timeout_seconds: int,
+    baseline_days: int,
+) -> dict[str, Any]:
+    function_name = discover_function(lambda_client, spec.logical_name)
+    log_group = f"/aws/lambda/{function_name}"
+    baseline = collect_baseline(logs_client, log_group, baseline_days)
+    started_ms = int(time.time() * 1000) - 1000
+    timing = invoke_profile(base_url, spec.path)
+    profile = wait_for_profile(
+        logs_client,
+        log_group,
+        started_ms,
+        timeout_seconds,
+    )
+
+    raw_profile = gzip.decompress(base64.b64decode(profile["encoded"]))
+    profile_path = output_dir / f"{route}.prof"
+    profile_path.write_bytes(raw_profile)
+
+    # The REPORT line can arrive just after the profile chunks. Briefly poll
+    # the one stream so metadata normally contains the same invocation report.
+    messages = []
+    for _ in range(10):
+        messages = read_log_stream(
+            logs_client, log_group, profile["log_stream"]
+        )
+        if extract_report(messages, profile["profile_id"]):
+            break
+        time.sleep(1)
+
+    import_trace = extract_import_trace(messages)
+    import_path = output_dir / f"{route}.importtime"
+    import_path.write_text(import_trace, encoding="utf-8")
+
+    metadata = {
+        "route": route,
+        "function_name": function_name,
+        "log_group": log_group,
+        "log_stream": profile["log_stream"],
+        "profile_id": profile["profile_id"],
+        "baseline": baseline,
+        "invocation": asdict(timing),
+        "report": extract_report(messages, profile["profile_id"]),
+        "artifacts": {
+            "pstats": profile_path.name,
+            "importtime": import_path.name,
+        },
+    }
+    (output_dir / f"{route}.json").write_text(
+        json.dumps(metadata, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return metadata
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--route",
+        action="append",
+        choices=sorted(ROUTES),
+        required=True,
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://dev-api.tylernorlund.com",
+    )
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=60)
+    parser.add_argument("--baseline-days", type=int, default=7)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    lambda_client = boto3.client("lambda", region_name=args.region)
+    logs_client = boto3.client("logs", region_name=args.region)
+    results = []
+    for route in args.route:
+        results.append(
+            capture_route(
+                route,
+                ROUTES[route],
+                args.base_url,
+                args.output_dir,
+                lambda_client,
+                logs_client,
+                args.timeout_seconds,
+                args.baseline_days,
+            )
+        )
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capture_dev_api_profiles.py
+++ b/scripts/capture_dev_api_profiles.py
@@ -234,6 +234,24 @@ def extract_report(messages: list[str], request_id: str) -> dict[str, Any]:
     return {}
 
 
+def extract_cold_report(messages: list[str]) -> dict[str, Any]:
+    """Return the execution environment's REPORT line with INIT metadata."""
+    for message in messages:
+        match = REPORT_PATTERN.search(message)
+        init_match = INIT_DURATION_PATTERN.search(message)
+        if match is None or init_match is None:
+            continue
+        values = match.groupdict()
+        return {
+            "request_id": values["request_id"],
+            "duration_ms": float(values["duration"]),
+            "memory_size_mb": int(values["memory_size"]),
+            "max_memory_mb": int(values["max_memory"]),
+            "init_duration_ms": float(init_match.group("value")),
+        }
+    return {}
+
+
 def _percentile(values: list[float], percentile: float) -> float | None:
     if not values:
         return None
@@ -355,6 +373,7 @@ def capture_route(
         "profile_id": profile["profile_id"],
         "baseline": baseline,
         "cold_invocation": asdict(cold_timing),
+        "cold_report": extract_cold_report(messages),
         "invocation": asdict(timing),
         "report": extract_report(messages, profile["profile_id"]),
         "artifacts": {

--- a/scripts/capture_dev_api_profiles.py
+++ b/scripts/capture_dev_api_profiles.py
@@ -82,10 +82,14 @@ def discover_function(lambda_client, logical_name: str) -> str:
     return matches[0]
 
 
-def invoke_profile(base_url: str, path: str) -> InvocationTiming:
+def invoke_route(
+    base_url: str, path: str, *, profile: bool = False
+) -> InvocationTiming:
     """Invoke a route and measure response-header TTFB and total time."""
-    separator = "&" if "?" in path else "?"
-    url = f"{base_url.rstrip('/')}{path}{separator}__profile=1"
+    url = f"{base_url.rstrip('/')}{path}"
+    if profile:
+        separator = "&" if "?" in path else "?"
+        url = f"{url}{separator}__profile=1"
     request = urllib.request.Request(
         url,
         headers={"Accept": "application/json"},
@@ -315,7 +319,8 @@ def capture_route(
     log_group = f"/aws/lambda/{function_name}"
     baseline = collect_baseline(logs_client, log_group, baseline_days)
     started_ms = int(time.time() * 1000) - 1000
-    timing = invoke_profile(base_url, spec.path)
+    cold_timing = invoke_route(base_url, spec.path)
+    timing = invoke_route(base_url, spec.path, profile=True)
     profile = wait_for_profile(
         logs_client,
         log_group,
@@ -349,6 +354,7 @@ def capture_route(
         "log_stream": profile["log_stream"],
         "profile_id": profile["profile_id"],
         "baseline": baseline,
+        "cold_invocation": asdict(cold_timing),
         "invocation": asdict(timing),
         "report": extract_report(messages, profile["profile_id"]),
         "artifacts": {

--- a/scripts/test_capture_dev_api_profiles.py
+++ b/scripts/test_capture_dev_api_profiles.py
@@ -68,6 +68,24 @@ def test_extract_report_parses_lambda_report() -> None:
     }
 
 
+def test_extract_cold_report_finds_init_metadata() -> None:
+    messages = [
+        "REPORT RequestId: cold-request\tDuration: 210.0 ms\t"
+        "Memory Size: 1024 MB\tMax Memory Used: 98 MB\t"
+        "Init Duration: 320.5 ms",
+        "REPORT RequestId: warm-request\tDuration: 12.0 ms\t"
+        "Memory Size: 1024 MB\tMax Memory Used: 98 MB",
+    ]
+
+    assert capture.extract_cold_report(messages) == {
+        "request_id": "cold-request",
+        "duration_ms": 210.0,
+        "memory_size_mb": 1024,
+        "max_memory_mb": 98,
+        "init_duration_ms": 320.5,
+    }
+
+
 def test_percentile_uses_nearest_rank() -> None:
     assert capture._percentile([4.0, 1.0, 3.0, 2.0], 0.50) == 2.0
     assert capture._percentile([4.0, 1.0, 3.0, 2.0], 0.99) == 4.0

--- a/scripts/test_capture_dev_api_profiles.py
+++ b/scripts/test_capture_dev_api_profiles.py
@@ -1,0 +1,74 @@
+"""Unit tests for dev API Lambda profile reconstruction."""
+
+import base64
+import gzip
+import json
+
+from scripts import capture_dev_api_profiles as capture
+
+
+def _event(profile_id, sequence, total, data, timestamp=1):
+    message = {
+        "profile_id": profile_id,
+        "sequence": sequence,
+        "total": total,
+        "data": data,
+    }
+    return {
+        "message": capture.PROFILE_MARKER + json.dumps(message),
+        "timestamp": timestamp,
+        "logStreamName": "stream",
+    }
+
+
+def test_complete_profiles_reassembles_ordered_chunks() -> None:
+    payload = base64.b64encode(gzip.compress(b"profile-data")).decode("ascii")
+    midpoint = len(payload) // 2
+    events = [
+        _event("profile", 1, 2, payload[midpoint:], timestamp=2),
+        _event("profile", 0, 2, payload[:midpoint]),
+    ]
+
+    profiles = capture._complete_profiles(events)
+
+    assert len(profiles) == 1
+    assert profiles[0]["encoded"] == payload
+    assert profiles[0]["timestamp"] == 2
+
+
+def test_complete_profiles_ignores_incomplete_payloads() -> None:
+    assert capture._complete_profiles([_event("profile", 0, 2, "a")]) == []
+
+
+def test_extract_import_trace_removes_lambda_prefix() -> None:
+    messages = [
+        "2026-01-01 import time: self [us] | cumulative | imported package",
+        "import time:       100 |        100 | json",
+        "START RequestId: request",
+    ]
+
+    assert capture.extract_import_trace(messages) == (
+        "import time: self [us] | cumulative | imported package\n"
+        "import time:       100 |        100 | json\n"
+    )
+
+
+def test_extract_report_parses_lambda_report() -> None:
+    messages = [
+        "REPORT RequestId: request-1\tDuration: 123.45 ms\t"
+        "Billed Duration: 124 ms\tMemory Size: 1024 MB\t"
+        "Max Memory Used: 99 MB\tInit Duration: 210.5 ms"
+    ]
+
+    assert capture.extract_report(messages, "request-1") == {
+        "duration_ms": 123.45,
+        "memory_size_mb": 1024,
+        "max_memory_mb": 99,
+        "init_duration_ms": 210.5,
+    }
+
+
+def test_percentile_uses_nearest_rank() -> None:
+    assert capture._percentile([4.0, 1.0, 3.0, 2.0], 0.50) == 2.0
+    assert capture._percentile([4.0, 1.0, 3.0, 2.0], 0.99) == 4.0
+    assert capture._percentile([], 0.99) is None


### PR DESCRIPTION
## Summary

- add a request-gated, self-cleaning dev profiling workflow that captures import traces and cProfile flame graphs
- replace the broad `receipt_dynamo` dependency in the images and receipts routes with a focused read-only DynamoDB client cached across warm invocations
- bound image queries correctly so `limit=1` no longer performs an unbounded query and returns a 408 KB response

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [x] ⚡ Performance improvement
- [x] 🧪 Test changes or improved coverage

## Which Package(s) are Affected?

- [x] Infrastructure (Pulumi)
- [x] CI/CD Workflows
- [x] Other: API Lambda handlers

## Dev performance results

| Measurement | `/images` | `/receipts` |
| --- | ---: | ---: |
| Cold INIT | 771 ms → 319 ms | 813 ms → 316 ms |
| Clean cold TTFB | 1.87 s → 0.96 s | 1.62 s → 0.97 s |
| Warm Lambda duration | 871 ms → 35 ms | 539 ms → 42 ms |
| Profiled application work | 764 ms → ~9 ms | 400 ms → ~9 ms |
| Response size | 408 KB → 1.6 KB | 1.8 KB |

The final cold measurements were taken after the profiling environment variables were removed. Ten clean warm requests produced TTFB medians of 315 ms for images and 312 ms for receipts.

## Testing

- [x] 25 focused unit and infrastructure tests pass locally
- [x] Full branch CI passed
- [x] Deployed and profiled both functions on the dev Pulumi stack
- [x] Verified status, response schemas, limits, and pagination against dev
- [x] Verified the cleanup deployment removed `LAMBDA_PROFILE_ENABLED` and `PYTHONPROFILEIMPORTTIME`

Dev profiling run: https://github.com/tnorlund/Portfolio/actions/runs/32411988847

## Related Issues

Relates to #1474

## Impact Analysis

The public response contracts remain unchanged. The images and receipts routes now query only the indexes and attributes they require. DynamoDB clients are reused for warm invocations. The profiling code is inert unless the manual dev workflow explicitly enables it.

SnapStart is intentionally not enabled here. After the code changes, measured INIT is approximately 316–319 ms, so the extra version and alias machinery has limited upside. It can be tested separately if production cold p99 remains above the desired target.

## Deployment Notes

Deploy through the normal Pulumi workflow. No migration or manual configuration is required. Rollback is the normal application and infrastructure revision rollback.